### PR TITLE
feat: enhance DM replies with conversation history context

### DIFF
--- a/lib/redditClient.js
+++ b/lib/redditClient.js
@@ -198,4 +198,121 @@ async function getUserOverview(username, limit = 10) {
   }
 }
 
-export { submitTextPost, getNewPosts, getNewComments, getNewDMs, sendDM, commentOnPost, replyDM, replyToComment, getUserOverview };
+/**
+ * Normalize a Reddit username for safe comparison.
+ * Strips leading "u/" or "/u/" prefixes and lowercases.
+ */
+function normalizeUsername(name) {
+  if (!name) return '';
+  return name.replace(/^\/?(u\/)/i, '').toLowerCase();
+}
+
+/**
+ * Check if a message item is a genuine DM (not a comment reply).
+ * Filters by kind === 't4' and was_comment === false.
+ */
+function isPrivateMessage(child) {
+  return child.kind === 't4' && child.data.was_comment === false;
+}
+
+async function getInboxMessagesFromUser(username, limit = 40) {
+  try {
+    const collectedMessages = [];
+    let after = null;
+    const maxPages = 3;
+    const normalizedTarget = normalizeUsername(username);
+    const normalizedBot = normalizeUsername(process.env.REDDIT_USERNAME);
+
+    for (let page = 0; page < maxPages && collectedMessages.length < limit; page++) {
+      const params = {
+        limit: 100,
+        show: 'all',
+      };
+      if (after) params.after = after;
+
+      const response = await reddit.get('/message/messages', params);
+      if (!response.data || !response.data.children || response.data.children.length === 0) break;
+
+      let matchesOnThisPage = 0;
+
+      for (const child of response.data.children) {
+        // Fix #3: Only process genuine private messages (t4), skip comment replies
+        if (!isPrivateMessage(child)) continue;
+
+        const msg = child.data;
+        // Fix #1: Case-insensitive comparison with u/ prefix stripping
+        const normalizedAuthor = normalizeUsername(msg.author);
+        const normalizedDest = normalizeUsername(msg.dest);
+        const isSentByUser = normalizedAuthor === normalizedTarget;
+        const isSentByBot = normalizedAuthor === normalizedBot && normalizedDest === normalizedTarget;
+
+        if ((isSentByUser || isSentByBot) && msg.body) {
+          collectedMessages.push({
+            id: msg.id,
+            sender: msg.author,
+            recipient: msg.dest,
+            body: msg.body,
+            subject: msg.subject || '',
+            created_utc: msg.created_utc,
+            direction: isSentByBot ? 'bot' : 'user',
+          });
+          matchesOnThisPage++;
+        }
+
+        // Also check replies in the message thread
+        if (msg.replies && msg.replies.data && msg.replies.data.children) {
+          for (const reply of msg.replies.data.children) {
+            // Fix #3: Filter nested replies too
+            if (reply.kind !== 't4') continue;
+
+            const replyData = reply.data;
+            const normalizedReplyAuthor = normalizeUsername(replyData.author);
+            const normalizedReplyDest = normalizeUsername(replyData.dest);
+            const isReplyByUser = normalizedReplyAuthor === normalizedTarget;
+            const isReplyByBot = normalizedReplyAuthor === normalizedBot && normalizedReplyDest === normalizedTarget;
+
+            if ((isReplyByUser || isReplyByBot) && replyData.body) {
+              collectedMessages.push({
+                id: replyData.id,
+                sender: replyData.author,
+                recipient: replyData.dest,
+                body: replyData.body,
+                subject: replyData.subject || '',
+                created_utc: replyData.created_utc,
+                direction: isReplyByBot ? 'bot' : 'user',
+              });
+              matchesOnThisPage++;
+            }
+          }
+        }
+
+        if (collectedMessages.length >= limit) break;
+      }
+
+      // Fix #2: Early exit — if an entire page had zero matches for this user,
+      // there's no point fetching further back in time
+      if (matchesOnThisPage === 0) {
+        console.log(`No messages from ${username} on page ${page + 1}, stopping pagination early`);
+        break;
+      }
+
+      after = response.data.after;
+      if (!after) break;
+    }
+
+    // Deduplicate by message ID
+    const uniqueMessages = [...new Map(collectedMessages.map(m => [m.id, m])).values()];
+
+    // Sort chronologically (oldest first) and take the last `limit`
+    uniqueMessages.sort((a, b) => a.created_utc - b.created_utc);
+    const result = uniqueMessages.slice(-limit);
+
+    console.log(`Fetched ${result.length} inbox messages from/to user ${username} (out of ${uniqueMessages.length} total)`);
+    return result;
+  } catch (error) {
+    console.error(`Error fetching inbox messages for user ${username}:`, error.message);
+    return [];
+  }
+}
+
+export { submitTextPost, getNewPosts, getNewComments, getNewDMs, sendDM, commentOnPost, replyDM, replyToComment, getUserOverview, getInboxMessagesFromUser };

--- a/processors/dmProcessor.js
+++ b/processors/dmProcessor.js
@@ -1,11 +1,44 @@
 import { generateResponse } from '../handlers/responseGenerator.js';
-import { replyDM, getUserOverview } from '../lib/redditClient.js';
+import { replyDM, getUserOverview, getInboxMessagesFromUser } from '../lib/redditClient.js';
+
+const MAX_MSGS = 40;
+
+async function buildConversationContext(sender) {
+  try {
+    const inboxMessages = await getInboxMessagesFromUser(sender, MAX_MSGS);
+
+    if (inboxMessages.length === 0) {
+      console.log(`No conversation history found for user ${sender}`);
+      return '';
+    }
+
+    const conversationLines = inboxMessages.map((msg) => {
+      const role = msg.direction === 'bot' ? '[bot]' : `[${sender}]`;
+      const timestamp = new Date(msg.created_utc * 1000).toISOString();
+      return `${role} (${timestamp}): ${msg.body}`;
+    });
+
+    console.log(`Built conversation context for ${sender}: ${inboxMessages.length} messages`);
+    return `\nConversation History with u/${sender} (last ${inboxMessages.length} messages, chronological order):\n${conversationLines.join('\n')}\n`;
+  } catch (error) {
+    console.error(`Error building conversation context for ${sender}:`, error.message);
+    return '';
+  }
+}
 
 async function newDMProcessor(messages) {
   for (const message of messages) {
     try {
       console.log(`Processing DM ${message.id} from ${message.sender}: ${message.body.slice(0, 100)}...`);
-      let response = await generateResponse(message, true, false, `This message is from u/${message.sender}`);
+
+      // Fetch conversation history for richer context
+      const conversationContext = await buildConversationContext(message.sender);
+      const baseContext = `This message is from u/${message.sender}`;
+      const fullContext = conversationContext
+        ? `${baseContext}\n${conversationContext}`
+        : baseContext;
+
+      let response = await generateResponse(message, true, false, fullContext);
       while (response.action === 'query_user') {
         const username = response.text;
         console.log(`Querying user ${username} for DM ${message.id}`);
@@ -13,7 +46,7 @@ async function newDMProcessor(messages) {
         const userContext = userData
           .map((item) => `${item.kind === 't3' ? 'Post' : 'Comment'} in r/${item.subreddit}: ${item.content}`)
           .join('\n');
-        response = await generateResponse(message, true, false, `User ${username} context:\n${userContext}`);
+        response = await generateResponse(message, true, false, `${fullContext}\nUser ${username} context:\n${userContext}`);
       }
       if (response.action === 'reply' && response.text !== '0canthelpwiththisquery0') {
         await replyDM(message.id, response.text);


### PR DESCRIPTION
Fetch the last 40 messages from a user's inbox to build conversation context before generating a DM reply. This gives the LLM awareness of prior exchanges for higher quality, context-aware responses.

### Changes

- **`lib/redditClient.js`**
  - Added `getInboxMessagesFromUser(username, limit)` — fetches and filters inbox messages exchanged with a specific user (both sent and received), with pagination and deduplication
  - Added `normalizeUsername()` helper for case-insensitive, prefix-safe username comparison
  - Added `isPrivateMessage()` helper to filter only genuine DMs (`t4`, `was_comment === false`)

- **`processors/dmProcessor.js`**
  - Added `buildConversationContext(sender)` — formats conversation history with `[bot]`/`[user]` labels and timestamps
  - Updated `newDMProcessor()` to inject conversation history into `additionalContext` before calling `generateResponse()`
  - Conversation context is preserved through `query_user` follow-up loops

### Bug Fixes

- Case-insensitive username matching (Reddit API may return inconsistent casing)
- Early pagination exit when no matches found on a page (reduces unnecessary API calls)
- Strict `t4` + `was_comment` filtering to prevent comment replies from polluting DM context