### PR TITLE
feat: add Reddit post response script and integrate response generation

### DIFF
--- a/handlers/responseGenerator.js
+++ b/handlers/responseGenerator.js
@@ -67,9 +67,44 @@ async function describeImage(base64Data, mimeType) {
   }
 }
 
+function getFfmpegPath() {
+  try {
+    execSync(`"${ffmpeg.path}" -version`, { stdio: 'ignore' });
+    return ffmpeg.path;
+  } catch (e) {
+    console.warn(`[VISION] NPM-installed ffmpeg failed/segfaulted. Falling back to system ffmpeg.`);
+    try {
+      execSync('ffmpeg -version', { stdio: 'ignore' });
+      return 'ffmpeg';
+    } catch (sysErr) {
+      console.error('[VISION] System ffmpeg not found.');
+      return ffmpeg.path;
+    }
+  }
+}
+
+function getFfprobePath() {
+  try {
+    execSync(`"${ffprobe.path}" -version`, { stdio: 'ignore' });
+    return ffprobe.path;
+  } catch (e) {
+    console.warn(`[VISION] NPM-installed ffprobe failed/segfaulted. Falling back to system ffprobe.`);
+    try {
+      execSync('ffprobe -version', { stdio: 'ignore' });
+      return 'ffprobe';
+    } catch (sysErr) {
+      console.error('[VISION] System ffprobe not found.');
+      return ffprobe.path;
+    }
+  }
+}
+
 async function describeVideo(videoUrl) {
   const apiKey = process.env.NVIDIA_API_KEY;
   if (!apiKey) return '';
+
+  const ffmpegPath = getFfmpegPath();
+  const ffprobePath = getFfprobePath();
 
   const tempDir = path.join(process.cwd(), 'scratch', `video_temp_${Date.now()}`);
   try {
@@ -77,7 +112,7 @@ async function describeVideo(videoUrl) {
 
     let duration = 10;
     try {
-      const durationStr = execSync(`"${ffprobe.path}" -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${videoUrl}"`).toString().trim();
+      const durationStr = execSync(`"${ffprobePath}" -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "${videoUrl}"`).toString().trim();
       const parsedDuration = parseFloat(durationStr);
       if (!isNaN(parsedDuration) && parsedDuration > 0) {
         duration = parsedDuration;
@@ -90,7 +125,7 @@ async function describeVideo(videoUrl) {
     const fps = (5 / duration).toFixed(4);
     console.log(`[VISION] Extracting frames from video URL: ${videoUrl} with fps=${fps}`);
     const outputPattern = path.join(tempDir, 'frame_%03d.jpg');
-    execSync(`"${ffmpeg.path}" -y -i "${videoUrl}" -vf "fps=${fps}" -vframes 5 "${outputPattern}"`, { stdio: 'ignore' });
+    execSync(`"${ffmpegPath}" -y -i "${videoUrl}" -vf "fps=${fps}" -vframes 5 "${outputPattern}"`, { stdio: 'ignore' });
 
     const files = fs.readdirSync(tempDir).filter(file => file.endsWith('.jpg')).sort();
     if (files.length === 0) {

--- a/scripts/testPostResponse.js
+++ b/scripts/testPostResponse.js
@@ -1,0 +1,73 @@
+import Reddit from 'reddit';
+import dotenv from 'dotenv';
+import { generateResponse } from '../handlers/responseGenerator.js';
+import { pool } from '../lib/database.js';
+
+dotenv.config();
+
+const reddit = new Reddit({
+  username: process.env.REDDIT_USERNAME,
+  password: process.env.REDDIT_PASSWORD,
+  appId: process.env.REDDIT_APP_ID,
+  appSecret: process.env.REDDIT_APP_SECRET,
+  userAgent: 'NITJalandhar/1.0.0 (by Opensource@NITJalandhar)',
+});
+
+async function run() {
+  const input = process.argv[2];
+  if (!input) {
+    console.error("Error: Please provide a Reddit post URL or Post ID.");
+    console.error("Usage: node scripts/testPostResponse.js <reddit_post_url_or_post_id>");
+    process.exit(1);
+  }
+
+  // Extract Reddit post ID (e.g. 1ubirgy) if a full URL is passed, otherwise use it directly
+  let postId = input;
+  if (input.includes('/comments/')) {
+    const match = input.match(/\/comments\/([a-z0-9]+)/i);
+    if (match) {
+      postId = match[1];
+    } else {
+      console.error("Error: Invalid Reddit post URL format.");
+      process.exit(1);
+    }
+  }
+
+  console.log(`Fetching post ${postId} from Reddit...`);
+  try {
+    const response = await reddit.get(`/comments/${postId}`);
+    const postData = response[0]?.data?.children[0]?.data;
+
+    if (!postData) {
+      throw new Error("Could not retrieve post data from Reddit API response.");
+    }
+
+    const postItem = {
+      id: postData.id,
+      title: postData.title,
+      selftext: postData.selftext || '',
+      author: postData.author,
+      created_utc: postData.created_utc,
+      post_hint: postData.post_hint || '',
+      url: postData.url || '',
+      is_video: postData.is_video || false,
+      video_url: postData.media?.reddit_video?.fallback_url || postData.secure_media?.reddit_video?.fallback_url || '',
+    };
+
+    console.log(`Generating response for post ${postItem.id}: "${postItem.title}"`);
+    console.log(`Post Type: ${postItem.is_video ? 'VIDEO' : postItem.post_hint === 'image' ? 'IMAGE' : 'TEXT'}`);
+
+    const result = await generateResponse(postItem, false, false);
+    
+    console.log("\n=== Bot Generated Response ===");
+    console.log(JSON.stringify(result, null, 2));
+    console.log("==============================\n");
+
+  } catch (error) {
+    console.error("Execution failed:", error.message);
+  } finally {
+    await pool.end();
+  }
+}
+
+run();


### PR DESCRIPTION
This pull request improves the reliability of video processing in the response generator and adds a new script for testing Reddit post responses. The most significant changes are the introduction of fallback logic for ffmpeg/ffprobe binaries and the addition of a utility script to fetch and process Reddit posts.

**Video processing reliability improvements:**
- Added `getFfmpegPath()` and `getFfprobePath()` helper functions to attempt using the NPM-installed `ffmpeg`/`ffprobe` binaries first, and fall back to the system binaries if the NPM versions fail. This ensures video frame extraction works even if the bundled binaries are broken or missing. (`handlers/responseGenerator.js`)
- Updated all uses of `ffmpeg.path` and `ffprobe.path` in video processing to use the new helper functions, improving robustness for video duration detection and frame extraction. (`handlers/responseGenerator.js`) [[1]](diffhunk://#diff-dfc51d4a00c7108005985238178112c5ea4b9a38db9865f9fa6013d403614729R70-R115) [[2]](diffhunk://#diff-dfc51d4a00c7108005985238178112c5ea4b9a38db9865f9fa6013d403614729L93-R128)

**Developer tooling:**
- Added a new script `testPostResponse.js` that allows developers to fetch a Reddit post by URL or ID, generate a bot response using `generateResponse`, and print the result. This script helps with local testing and debugging of post processing logic. (`scripts/testPostResponse.js`)