### PR TITLE
Support .txt and .md files and organize placement data

### DIFF
--- a/assets/AskNITJ_Placements_2026_Master_Context.md
+++ b/assets/AskNITJ_Placements_2026_Master_Context.md
@@ -1,0 +1,3314 @@
+# AskNITJ Placements 2026 Master Context
+
+> Consolidated placement data, schedules, company visits, and statistics.
+
+---
+
+{
+  "offersVsDate": [
+    {
+      "date": "2025-08-01",
+      "count": 8
+    },
+    {
+      "date": "2025-08-05",
+      "count": 13
+    },
+    {
+      "date": "2025-08-07",
+      "count": 19
+    },
+    {
+      "date": "2025-08-08",
+      "count": 21
+    },
+    {
+      "date": "2025-08-12",
+      "count": 31
+    },
+    {
+      "date": "2025-08-13",
+      "count": 44
+    },
+    {
+      "date": "2025-08-19",
+      "count": 59
+    },
+    {
+      "date": "2025-08-20",
+      "count": 60
+    },
+    {
+      "date": "2025-08-25",
+      "count": 76
+    },
+    {
+      "date": "2025-08-28",
+      "count": 77
+    },
+    {
+      "date": "2025-08-29",
+      "count": 80
+    },
+    {
+      "date": "2025-09-01",
+      "count": 89
+    },
+    {
+      "date": "2025-09-02",
+      "count": 99
+    },
+    {
+      "date": "2025-09-04",
+      "count": 100
+    },
+    {
+      "date": "2025-09-08",
+      "count": 102
+    },
+    {
+      "date": "2025-09-10",
+      "count": 107
+    },
+    {
+      "date": "2025-09-11",
+      "count": 117
+    },
+    {
+      "date": "2025-09-17",
+      "count": 119
+    },
+    {
+      "date": "2025-09-20",
+      "count": 121
+    },
+    {
+      "date": "2025-09-30",
+      "count": 216
+    },
+    {
+      "date": "2025-10-01",
+      "count": 217
+    },
+    {
+      "date": "2025-10-02",
+      "count": 218
+    },
+    {
+      "date": "2025-10-07",
+      "count": 219
+    },
+    {
+      "date": "2025-10-10",
+      "count": 236
+    },
+    {
+      "date": "2025-10-11",
+      "count": 237
+    },
+    {
+      "date": "2025-10-13",
+      "count": 249
+    },
+    {
+      "date": "2025-10-14",
+      "count": 250
+    },
+    {
+      "date": "2025-10-15",
+      "count": 289
+    },
+    {
+      "date": "2025-10-18",
+      "count": 294
+    },
+    {
+      "date": "2025-10-22",
+      "count": 312
+    },
+    {
+      "date": "2025-10-23",
+      "count": 316
+    },
+    {
+      "date": "2025-10-24",
+      "count": 320
+    },
+    {
+      "date": "2025-10-27",
+      "count": 322
+    },
+    {
+      "date": "2025-10-28",
+      "count": 324
+    },
+    {
+      "date": "2025-10-29",
+      "count": 333
+    },
+    {
+      "date": "2025-10-30",
+      "count": 337
+    },
+    {
+      "date": "2025-10-31",
+      "count": 341
+    },
+    {
+      "date": "2025-11-01",
+      "count": 348
+    },
+    {
+      "date": "2025-11-04",
+      "count": 352
+    },
+    {
+      "date": "2025-11-06",
+      "count": 354
+    },
+    {
+      "date": "2025-11-07",
+      "count": 355
+    },
+    {
+      "date": "2025-11-11",
+      "count": 362
+    },
+    {
+      "date": "2025-11-13",
+      "count": 370
+    },
+    {
+      "date": "2025-11-14",
+      "count": 381
+    },
+    {
+      "date": "2025-11-15",
+      "count": 383
+    },
+    {
+      "date": "2025-11-17",
+      "count": 388
+    },
+    {
+      "date": "2025-11-18",
+      "count": 393
+    },
+    {
+      "date": "2025-11-19",
+      "count": 407
+    },
+    {
+      "date": "2025-11-20",
+      "count": 425
+    },
+    {
+      "date": "2025-11-21",
+      "count": 444
+    },
+    {
+      "date": "2025-11-22",
+      "count": 459
+    },
+    {
+      "date": "2025-11-25",
+      "count": 475
+    },
+    {
+      "date": "2025-11-26",
+      "count": 488
+    },
+    {
+      "date": "2025-11-27",
+      "count": 492
+    },
+    {
+      "date": "2025-11-28",
+      "count": 499
+    },
+    {
+      "date": "2025-12-01",
+      "count": 501
+    },
+    {
+      "date": "2025-12-02",
+      "count": 511
+    },
+    {
+      "date": "2025-12-03",
+      "count": 512
+    },
+    {
+      "date": "2025-12-04",
+      "count": 519
+    },
+    {
+      "date": "2025-12-05",
+      "count": 522
+    },
+    {
+      "date": "2025-12-09",
+      "count": 530
+    },
+    {
+      "date": "2025-12-10",
+      "count": 532
+    },
+    {
+      "date": "2025-12-11",
+      "count": 550
+    },
+    {
+      "date": "2025-12-12",
+      "count": 569
+    },
+    {
+      "date": "2025-12-14",
+      "count": 574
+    },
+    {
+      "date": "2025-12-15",
+      "count": 577
+    },
+    {
+      "date": "2025-12-16",
+      "count": 585
+    },
+    {
+      "date": "2025-12-17",
+      "count": 596
+    },
+    {
+      "date": "2025-12-18",
+      "count": 603
+    },
+    {
+      "date": "2025-12-19",
+      "count": 607
+    },
+    {
+      "date": "2025-12-20",
+      "count": 618
+    },
+    {
+      "date": "2025-12-22",
+      "count": 620
+    },
+    {
+      "date": "2025-12-23",
+      "count": 636
+    },
+    {
+      "date": "2025-12-24",
+      "count": 640
+    },
+    {
+      "date": "2025-12-25",
+      "count": 641
+    },
+    {
+      "date": "2025-12-27",
+      "count": 663
+    },
+    {
+      "date": "2025-12-30",
+      "count": 665
+    },
+    {
+      "date": "2025-12-31",
+      "count": 666
+    },
+    {
+      "date": "2026-01-01",
+      "count": 667
+    },
+    {
+      "date": "2026-01-02",
+      "count": 669
+    },
+    {
+      "date": "2026-01-03",
+      "count": 670
+    },
+    {
+      "date": "2026-01-05",
+      "count": 671
+    },
+    {
+      "date": "2026-01-06",
+      "count": 672
+    },
+    {
+      "date": "2026-01-08",
+      "count": 673
+    },
+    {
+      "date": "2026-01-09",
+      "count": 686
+    },
+    {
+      "date": "2026-01-10",
+      "count": 689
+    },
+    {
+      "date": "2026-01-12",
+      "count": 690
+    },
+    {
+      "date": "2026-01-13",
+      "count": 691
+    },
+    {
+      "date": "2026-01-14",
+      "count": 692
+    },
+    {
+      "date": "2026-01-15",
+      "count": 703
+    },
+    {
+      "date": "2026-01-16",
+      "count": 714
+    },
+    {
+      "date": "2026-01-17",
+      "count": 716
+    },
+    {
+      "date": "2026-01-19",
+      "count": 721
+    },
+    {
+      "date": "2026-01-21",
+      "count": 728
+    },
+    {
+      "date": "2026-01-23",
+      "count": 729
+    },
+    {
+      "date": "2026-01-24",
+      "count": 743
+    },
+    {
+      "date": "2026-01-27",
+      "count": 745
+    },
+    {
+      "date": "2026-01-31",
+      "count": 749
+    },
+    {
+      "date": "2026-02-03",
+      "count": 751
+    },
+    {
+      "date": "2026-02-04",
+      "count": 753
+    },
+    {
+      "date": "2026-02-05",
+      "count": 758
+    },
+    {
+      "date": "2026-02-06",
+      "count": 760
+    },
+    {
+      "date": "2026-02-07",
+      "count": 761
+    },
+    {
+      "date": "2026-02-09",
+      "count": 765
+    },
+    {
+      "date": "2026-02-10",
+      "count": 767
+    },
+    {
+      "date": "2026-02-13",
+      "count": 770
+    },
+    {
+      "date": "2026-02-19",
+      "count": 781
+    },
+    {
+      "date": "2026-02-24",
+      "count": 782
+    },
+    {
+      "date": "2026-02-25",
+      "count": 788
+    },
+    {
+      "date": "2026-03-02",
+      "count": 791
+    },
+    {
+      "date": "2026-03-03",
+      "count": 796
+    },
+    {
+      "date": "2026-03-04",
+      "count": 798
+    },
+    {
+      "date": "2026-03-05",
+      "count": 800
+    },
+    {
+      "date": "2026-03-06",
+      "count": 801
+    },
+    {
+      "date": "2026-03-10",
+      "count": 803
+    },
+    {
+      "date": "2026-03-12",
+      "count": 804
+    },
+    {
+      "date": "2026-03-18",
+      "count": 807
+    },
+    {
+      "date": "2026-03-19",
+      "count": 809
+    },
+    {
+      "date": "2026-03-20",
+      "count": 811
+    },
+    {
+      "date": "2026-03-21",
+      "count": 812
+    },
+    {
+      "date": "2026-03-23",
+      "count": 812
+    },
+    {
+      "date": "2026-03-24",
+      "count": 821
+    },
+    {
+      "date": "2026-03-27",
+      "count": 822
+    },
+    {
+      "date": "2026-03-29",
+      "count": 830
+    },
+    {
+      "date": "2026-03-31",
+      "count": 831
+    },
+    {
+      "date": "2026-04-20",
+      "count": 839
+    },
+    {
+      "date": "2026-04-21",
+      "count": 854
+    },
+    {
+      "date": "2026-04-22",
+      "count": 856
+    },
+    {
+      "date": "2026-04-23",
+      "count": 858
+    },
+    {
+      "date": "2026-04-29",
+      "count": 864
+    },
+    {
+      "date": "2026-04-30",
+      "count": 865
+    },
+    {
+      "date": "2026-05-04",
+      "count": 876
+    },
+    {
+      "date": "2026-05-06",
+      "count": 880
+    },
+    {
+      "date": "2026-05-09",
+      "count": 884
+    },
+    {
+      "date": "2026-05-13",
+      "count": 890
+    },
+    {
+      "date": "2026-05-14",
+      "count": 894
+    },
+    {
+      "date": "2026-05-16",
+      "count": 895
+    },
+    {
+      "date": "2026-05-17",
+      "count": 898
+    },
+    {
+      "date": "2026-05-18",
+      "count": 898
+    },
+    {
+      "date": "2026-05-21",
+      "count": 907
+    },
+    {
+      "date": "2026-05-25",
+      "count": 909
+    },
+    {
+      "date": "2026-05-28",
+      "count": 910
+    },
+    {
+      "date": "2026-05-29",
+      "count": 913
+    },
+    {
+      "date": "2026-06-01",
+      "count": 918
+    },
+    {
+      "date": "2026-06-02",
+      "count": 919
+    },
+    {
+      "date": "2026-06-04",
+      "count": 920
+    },
+    {
+      "date": "2026-06-15",
+      "count": 921
+    },
+    {
+      "date": "2026-06-17",
+      "count": 922
+    }
+  ],
+  "totalPlacements": 923,
+  "uniquePlacements": 762,
+  "doublePlacements": 147,
+  "avgCTC": 11.05,
+  "highestCTC": 116,
+  "lowestCTC": 3.6,
+  "medianCTC": "9.31",
+  "placementsByDepartment": {
+    "TEXTILE TECHNOLOGY": 64,
+    "COMPUTER SCIENCE AND ENGINEERING": 166,
+    "ELECTRONICS AND COMMUNICATION ENGINEERING": 92,
+    "INFORMATION TECHNOLOGY": 104,
+    "INSTRUMENTATION AND CONTROL ENGINEERING": 108,
+    "CHEMICAL ENGINEERING": 75,
+    "ELECTRICAL ENGINEERING": 52,
+    "MECHANICAL ENGINEERING": 114,
+    "CIVIL ENGINEERING": 57,
+    "INDUSTRIAL AND PRODUCTION ENGINEERING": 71,
+    "BIO TECHNOLOGY": 20
+  },
+  "ctcBuckets": {
+    "\u003C5": 110,
+    "5-12": 528,
+    "12-20": 195,
+    "20-30": 59,
+    "30-40": 6,
+    "40+": 25
+  },
+  "genderDist": {
+    "Male": 710,
+    "Female": 213
+  },
+  "genderUnique": {
+    "Male": 580,
+    "Female": 182
+  },
+  "categoryDist": {
+    "OBC-NCL": 280,
+    "GEN-EWS": 190,
+    "General": 320,
+    "SC": 107,
+    "ST": 26
+  },
+  "jobTypeDist": {
+    "Intern": 56,
+    "FTE": 546,
+    "Intern+FTE": 153,
+    "Intern+PPO": 168
+  },
+  "sectorDist": {
+    "Private": 900,
+    "PSU": 23
+  },
+  "topCompanies": [
+    {
+      "company": "Reliance Industries Ltd ",
+      "count": 31
+    },
+    {
+      "company": "Accenture ",
+      "count": 21
+    },
+    {
+      "company": "Accenture",
+      "count": 19
+    },
+    {
+      "company": "HPCL-Mittal Energy Limited",
+      "count": 18
+    },
+    {
+      "company": "Oracle",
+      "count": 17
+    }
+  ],
+  "topCompaniesByCTC": [
+    {
+      "company": "ZS Campus Recruitment Process",
+      "maxCTC": null,
+      "avgCTC": null,
+      "totalOffers": 1
+    },
+    {
+      "company": "Technip Energies ",
+      "maxCTC": null,
+      "avgCTC": null,
+      "totalOffers": 1
+    },
+    {
+      "company": "Uber",
+      "maxCTC": null,
+      "avgCTC": null,
+      "totalOffers": 1
+    },
+    {
+      "company": "Ralson (India) Ltd",
+      "maxCTC": null,
+      "avgCTC": null,
+      "totalOffers": 1
+    },
+    {
+      "company": "TCS",
+      "maxCTC": null,
+      "avgCTC": null,
+      "totalOffers": 2
+    }
+  ],
+  "totalOffers": 301,
+  "totalCompanies": 349,
+  "summerTotalCompanies": 32,
+  "pendingCompanies": 7,
+  "offCampusCompanies": 61,
+  "onCampusCompanies": 256,
+  "totalEligibleStudents": 891,
+  "overallPlacementPercentage": 85.52,
+  "filterApplied": "B.Tech",
+  "departmentStats": {
+    "TEXTILE TECHNOLOGY": {
+      "totalOffers": 64,
+      "eligibleStudents": 57,
+      "uniqueStudents": 54,
+      "multipleOffers": 9,
+      "avgCTC": 6.34,
+      "highestCTC": 17,
+      "lowestCTC": 3.6,
+      "placementPercentage": 94.74,
+      "genderDist": {
+        "Male": 52,
+        "Female": 12
+      },
+      "genderUnique": {
+        "Male": 43,
+        "Female": 11
+      },
+      "ctcBuckets": {
+        "\u003C5": 36,
+        "5-12": 21,
+        "12-20": 7,
+        "20-30": 0,
+        "30-40": 0,
+        "40+": 0
+      },
+      "jobTypeDist": {
+        "Intern": 8,
+        "FTE": 45,
+        "Intern+PPO": 10,
+        "Intern+FTE": 1
+      },
+      "categoryDist": {
+        "OBC-NCL": 24,
+        "SC": 10,
+        "GEN-EWS": 14,
+        "General": 14,
+        "ST": 2
+      },
+      "industryDist": {
+        "Private": 64
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Sportsking",
+          "count": 8
+        },
+        {
+          "company": "Sangam India Limited",
+          "count": 7
+        },
+        {
+          "company": "Reliance Industries Ltd ",
+          "count": 6
+        },
+        {
+          "company": "Vardhman Textile",
+          "count": 4
+        },
+        {
+          "company": "Anatech Consulting Services",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "FNZ Technology (India) Private Limited",
+          "avgCTC": 17
+        },
+        {
+          "company": "Amazon ",
+          "avgCTC": 15.5
+        },
+        {
+          "company": "Jay Jay Mills (Pvt) LTD",
+          "avgCTC": 13.5
+        },
+        {
+          "company": "Trident Group",
+          "avgCTC": 12
+        },
+        {
+          "company": "Zomato ",
+          "avgCTC": 10
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-09-08",
+          "count": 2
+        },
+        {
+          "date": "2025-09-20",
+          "count": 4
+        },
+        {
+          "date": "2025-09-30",
+          "count": 6
+        },
+        {
+          "date": "2025-10-15",
+          "count": 16
+        },
+        {
+          "date": "2025-10-22",
+          "count": 23
+        },
+        {
+          "date": "2025-10-28",
+          "count": 25
+        },
+        {
+          "date": "2025-10-29",
+          "count": 26
+        },
+        {
+          "date": "2025-11-19",
+          "count": 28
+        },
+        {
+          "date": "2025-12-01",
+          "count": 29
+        },
+        {
+          "date": "2025-12-05",
+          "count": 31
+        },
+        {
+          "date": "2025-12-11",
+          "count": 32
+        },
+        {
+          "date": "2025-12-12",
+          "count": 33
+        },
+        {
+          "date": "2025-12-18",
+          "count": 36
+        },
+        {
+          "date": "2025-12-23",
+          "count": 39
+        },
+        {
+          "date": "2026-01-09",
+          "count": 40
+        },
+        {
+          "date": "2026-01-16",
+          "count": 43
+        },
+        {
+          "date": "2026-01-19",
+          "count": 44
+        },
+        {
+          "date": "2026-01-24",
+          "count": 47
+        },
+        {
+          "date": "2026-02-19",
+          "count": 49
+        },
+        {
+          "date": "2026-03-19",
+          "count": 50
+        },
+        {
+          "date": "2026-03-20",
+          "count": 52
+        },
+        {
+          "date": "2026-04-29",
+          "count": 53
+        },
+        {
+          "date": "2026-05-04",
+          "count": 57
+        },
+        {
+          "date": "2026-05-09",
+          "count": 61
+        },
+        {
+          "date": "2026-05-25",
+          "count": 63
+        }
+      ]
+    },
+    "COMPUTER SCIENCE AND ENGINEERING": {
+      "totalOffers": 166,
+      "eligibleStudents": 132,
+      "uniqueStudents": 130,
+      "multipleOffers": 32,
+      "avgCTC": 17.24,
+      "highestCTC": 52,
+      "lowestCTC": 3.6,
+      "placementPercentage": 98.48,
+      "genderDist": {
+        "Male": 130,
+        "Female": 36
+      },
+      "genderUnique": {
+        "Male": 101,
+        "Female": 29
+      },
+      "ctcBuckets": {
+        "\u003C5": 8,
+        "5-12": 65,
+        "12-20": 50,
+        "20-30": 26,
+        "30-40": 4,
+        "40+": 13
+      },
+      "jobTypeDist": {
+        "FTE": 75,
+        "Intern+FTE": 52,
+        "Intern+PPO": 31,
+        "Intern": 8
+      },
+      "categoryDist": {
+        "GEN-EWS": 29,
+        "General": 71,
+        "OBC-NCL": 44,
+        "SC": 19,
+        "ST": 3
+      },
+      "industryDist": {
+        "Private": 163,
+        "PSU": 3
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Oracle",
+          "count": 9
+        },
+        {
+          "company": "Accenture",
+          "count": 8
+        },
+        {
+          "company": "MAQ Software",
+          "count": 8
+        },
+        {
+          "company": "Microsoft",
+          "count": 6
+        },
+        {
+          "company": "OPTUM",
+          "count": 6
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Microsoft",
+          "avgCTC": 52
+        },
+        {
+          "company": "Google",
+          "avgCTC": 52
+        },
+        {
+          "company": "Amazon",
+          "avgCTC": 50.2
+        },
+        {
+          "company": "Matiks Mental Arithmetic Private Ltd",
+          "avgCTC": 32
+        },
+        {
+          "company": "Expedia Group",
+          "avgCTC": 31
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-01",
+          "count": 4
+        },
+        {
+          "date": "2025-08-05",
+          "count": 6
+        },
+        {
+          "date": "2025-08-12",
+          "count": 11
+        },
+        {
+          "date": "2025-08-13",
+          "count": 18
+        },
+        {
+          "date": "2025-08-25",
+          "count": 27
+        },
+        {
+          "date": "2025-08-28",
+          "count": 28
+        },
+        {
+          "date": "2025-08-29",
+          "count": 31
+        },
+        {
+          "date": "2025-09-01",
+          "count": 36
+        },
+        {
+          "date": "2025-09-02",
+          "count": 37
+        },
+        {
+          "date": "2025-09-10",
+          "count": 40
+        },
+        {
+          "date": "2025-09-11",
+          "count": 42
+        },
+        {
+          "date": "2025-09-17",
+          "count": 43
+        },
+        {
+          "date": "2025-09-30",
+          "count": 76
+        },
+        {
+          "date": "2025-10-01",
+          "count": 77
+        },
+        {
+          "date": "2025-10-07",
+          "count": 78
+        },
+        {
+          "date": "2025-10-14",
+          "count": 79
+        },
+        {
+          "date": "2025-10-15",
+          "count": 82
+        },
+        {
+          "date": "2025-10-18",
+          "count": 84
+        },
+        {
+          "date": "2025-10-23",
+          "count": 85
+        },
+        {
+          "date": "2025-10-24",
+          "count": 87
+        },
+        {
+          "date": "2025-10-29",
+          "count": 88
+        },
+        {
+          "date": "2025-11-01",
+          "count": 90
+        },
+        {
+          "date": "2025-11-04",
+          "count": 94
+        },
+        {
+          "date": "2025-11-07",
+          "count": 95
+        },
+        {
+          "date": "2025-11-11",
+          "count": 97
+        },
+        {
+          "date": "2025-11-15",
+          "count": 98
+        },
+        {
+          "date": "2025-11-21",
+          "count": 102
+        },
+        {
+          "date": "2025-11-25",
+          "count": 108
+        },
+        {
+          "date": "2025-11-26",
+          "count": 111
+        },
+        {
+          "date": "2025-12-01",
+          "count": 112
+        },
+        {
+          "date": "2025-12-02",
+          "count": 113
+        },
+        {
+          "date": "2025-12-05",
+          "count": 114
+        },
+        {
+          "date": "2025-12-11",
+          "count": 118
+        },
+        {
+          "date": "2025-12-12",
+          "count": 119
+        },
+        {
+          "date": "2025-12-15",
+          "count": 120
+        },
+        {
+          "date": "2025-12-17",
+          "count": 124
+        },
+        {
+          "date": "2025-12-18",
+          "count": 125
+        },
+        {
+          "date": "2025-12-22",
+          "count": 126
+        },
+        {
+          "date": "2025-12-23",
+          "count": 130
+        },
+        {
+          "date": "2025-12-24",
+          "count": 132
+        },
+        {
+          "date": "2025-12-27",
+          "count": 133
+        },
+        {
+          "date": "2025-12-30",
+          "count": 134
+        },
+        {
+          "date": "2026-01-01",
+          "count": 135
+        },
+        {
+          "date": "2026-01-02",
+          "count": 136
+        },
+        {
+          "date": "2026-01-06",
+          "count": 137
+        },
+        {
+          "date": "2026-01-08",
+          "count": 138
+        },
+        {
+          "date": "2026-01-09",
+          "count": 141
+        },
+        {
+          "date": "2026-01-10",
+          "count": 144
+        },
+        {
+          "date": "2026-01-12",
+          "count": 145
+        },
+        {
+          "date": "2026-01-15",
+          "count": 147
+        },
+        {
+          "date": "2026-01-23",
+          "count": 148
+        },
+        {
+          "date": "2026-01-31",
+          "count": 149
+        },
+        {
+          "date": "2026-02-05",
+          "count": 151
+        },
+        {
+          "date": "2026-02-09",
+          "count": 153
+        },
+        {
+          "date": "2026-02-10",
+          "count": 154
+        },
+        {
+          "date": "2026-02-13",
+          "count": 156
+        },
+        {
+          "date": "2026-03-02",
+          "count": 157
+        },
+        {
+          "date": "2026-03-18",
+          "count": 159
+        },
+        {
+          "date": "2026-03-31",
+          "count": 160
+        },
+        {
+          "date": "2026-04-21",
+          "count": 161
+        },
+        {
+          "date": "2026-04-23",
+          "count": 162
+        },
+        {
+          "date": "2026-05-17",
+          "count": 163
+        },
+        {
+          "date": "2026-05-29",
+          "count": 166
+        }
+      ]
+    },
+    "ELECTRONICS AND COMMUNICATION ENGINEERING": {
+      "totalOffers": 92,
+      "eligibleStudents": 102,
+      "uniqueStudents": 75,
+      "multipleOffers": 15,
+      "avgCTC": 14.2,
+      "highestCTC": 52,
+      "lowestCTC": 4,
+      "placementPercentage": 73.53,
+      "genderDist": {
+        "Male": 69,
+        "Female": 23
+      },
+      "genderUnique": {
+        "Male": 56,
+        "Female": 19
+      },
+      "ctcBuckets": {
+        "\u003C5": 8,
+        "5-12": 41,
+        "12-20": 28,
+        "20-30": 10,
+        "30-40": 2,
+        "40+": 3
+      },
+      "jobTypeDist": {
+        "FTE": 54,
+        "Intern+FTE": 13,
+        "Intern+PPO": 21,
+        "Intern": 4
+      },
+      "categoryDist": {
+        "GEN-EWS": 12,
+        "OBC-NCL": 28,
+        "General": 38,
+        "SC": 9,
+        "ST": 5
+      },
+      "industryDist": {
+        "Private": 84,
+        "PSU": 8
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Bharat Electronics Limited (BEL)",
+          "count": 8
+        },
+        {
+          "company": "Accenture ",
+          "count": 6
+        },
+        {
+          "company": "Elevate Standard",
+          "count": 5
+        },
+        {
+          "company": "HSBC Technology",
+          "count": 4
+        },
+        {
+          "company": "Silicon Labs",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Microsoft",
+          "avgCTC": 52
+        },
+        {
+          "company": "Amazon",
+          "avgCTC": 52
+        },
+        {
+          "company": "Silicon Labs",
+          "avgCTC": 30
+        },
+        {
+          "company": "NXP Semiconductors (B.Tech) ",
+          "avgCTC": 26
+        },
+        {
+          "company": "CISCO",
+          "avgCTC": 24.73
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-01",
+          "count": 1
+        },
+        {
+          "date": "2025-08-05",
+          "count": 2
+        },
+        {
+          "date": "2025-08-12",
+          "count": 3
+        },
+        {
+          "date": "2025-08-13",
+          "count": 5
+        },
+        {
+          "date": "2025-08-19",
+          "count": 7
+        },
+        {
+          "date": "2025-08-25",
+          "count": 9
+        },
+        {
+          "date": "2025-09-01",
+          "count": 11
+        },
+        {
+          "date": "2025-09-11",
+          "count": 15
+        },
+        {
+          "date": "2025-09-30",
+          "count": 23
+        },
+        {
+          "date": "2025-10-15",
+          "count": 25
+        },
+        {
+          "date": "2025-10-22",
+          "count": 27
+        },
+        {
+          "date": "2025-10-24",
+          "count": 29
+        },
+        {
+          "date": "2025-10-30",
+          "count": 30
+        },
+        {
+          "date": "2025-11-01",
+          "count": 32
+        },
+        {
+          "date": "2025-11-11",
+          "count": 33
+        },
+        {
+          "date": "2025-11-14",
+          "count": 34
+        },
+        {
+          "date": "2025-11-15",
+          "count": 35
+        },
+        {
+          "date": "2025-11-19",
+          "count": 36
+        },
+        {
+          "date": "2025-11-21",
+          "count": 37
+        },
+        {
+          "date": "2025-11-25",
+          "count": 40
+        },
+        {
+          "date": "2025-11-26",
+          "count": 41
+        },
+        {
+          "date": "2025-12-11",
+          "count": 46
+        },
+        {
+          "date": "2025-12-12",
+          "count": 49
+        },
+        {
+          "date": "2025-12-17",
+          "count": 53
+        },
+        {
+          "date": "2025-12-20",
+          "count": 61
+        },
+        {
+          "date": "2025-12-23",
+          "count": 63
+        },
+        {
+          "date": "2026-01-09",
+          "count": 65
+        },
+        {
+          "date": "2026-01-15",
+          "count": 67
+        },
+        {
+          "date": "2026-02-19",
+          "count": 69
+        },
+        {
+          "date": "2026-02-25",
+          "count": 71
+        },
+        {
+          "date": "2026-03-05",
+          "count": 73
+        },
+        {
+          "date": "2026-03-29",
+          "count": 75
+        },
+        {
+          "date": "2026-04-21",
+          "count": 79
+        },
+        {
+          "date": "2026-04-22",
+          "count": 81
+        },
+        {
+          "date": "2026-04-29",
+          "count": 86
+        },
+        {
+          "date": "2026-05-06",
+          "count": 87
+        },
+        {
+          "date": "2026-05-13",
+          "count": 88
+        },
+        {
+          "date": "2026-05-17",
+          "count": 89
+        },
+        {
+          "date": "2026-06-01",
+          "count": 91
+        },
+        {
+          "date": "2026-06-15",
+          "count": 92
+        }
+      ]
+    },
+    "INFORMATION TECHNOLOGY": {
+      "totalOffers": 104,
+      "eligibleStudents": 103,
+      "uniqueStudents": 85,
+      "multipleOffers": 17,
+      "avgCTC": 14.33,
+      "highestCTC": 52,
+      "lowestCTC": 6,
+      "placementPercentage": 82.52,
+      "genderDist": {
+        "Male": 81,
+        "Female": 23
+      },
+      "genderUnique": {
+        "Male": 65,
+        "Female": 20
+      },
+      "ctcBuckets": {
+        "\u003C5": 8,
+        "5-12": 47,
+        "12-20": 34,
+        "20-30": 10,
+        "30-40": 0,
+        "40+": 5
+      },
+      "jobTypeDist": {
+        "FTE": 38,
+        "Intern+FTE": 29,
+        "Intern+PPO": 28,
+        "Intern": 9
+      },
+      "categoryDist": {
+        "OBC-NCL": 26,
+        "GEN-EWS": 15,
+        "General": 52,
+        "ST": 2,
+        "SC": 9
+      },
+      "industryDist": {
+        "Private": 103,
+        "PSU": 1
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Samsung SRI-Delhi",
+          "count": 7
+        },
+        {
+          "company": "GlobalLogic",
+          "count": 6
+        },
+        {
+          "company": "HSBC Technology",
+          "count": 4
+        },
+        {
+          "company": "Amazon",
+          "count": 4
+        },
+        {
+          "company": "Accenture",
+          "count": 3
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Microsoft",
+          "avgCTC": 52
+        },
+        {
+          "company": "Amazon ",
+          "avgCTC": 52
+        },
+        {
+          "company": "Amazon",
+          "avgCTC": 41.2
+        },
+        {
+          "company": "CISCO",
+          "avgCTC": 24.73
+        },
+        {
+          "company": "Urban Company",
+          "avgCTC": 24
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-01",
+          "count": 3
+        },
+        {
+          "date": "2025-08-05",
+          "count": 5
+        },
+        {
+          "date": "2025-08-08",
+          "count": 7
+        },
+        {
+          "date": "2025-08-12",
+          "count": 10
+        },
+        {
+          "date": "2025-08-13",
+          "count": 13
+        },
+        {
+          "date": "2025-08-25",
+          "count": 16
+        },
+        {
+          "date": "2025-09-01",
+          "count": 17
+        },
+        {
+          "date": "2025-09-02",
+          "count": 18
+        },
+        {
+          "date": "2025-09-10",
+          "count": 20
+        },
+        {
+          "date": "2025-09-11",
+          "count": 24
+        },
+        {
+          "date": "2025-09-30",
+          "count": 41
+        },
+        {
+          "date": "2025-10-10",
+          "count": 42
+        },
+        {
+          "date": "2025-10-18",
+          "count": 44
+        },
+        {
+          "date": "2025-10-23",
+          "count": 46
+        },
+        {
+          "date": "2025-10-30",
+          "count": 47
+        },
+        {
+          "date": "2025-11-11",
+          "count": 50
+        },
+        {
+          "date": "2025-11-19",
+          "count": 51
+        },
+        {
+          "date": "2025-11-21",
+          "count": 60
+        },
+        {
+          "date": "2025-11-22",
+          "count": 62
+        },
+        {
+          "date": "2025-11-25",
+          "count": 65
+        },
+        {
+          "date": "2025-11-26",
+          "count": 67
+        },
+        {
+          "date": "2025-12-02",
+          "count": 69
+        },
+        {
+          "date": "2025-12-11",
+          "count": 72
+        },
+        {
+          "date": "2025-12-12",
+          "count": 73
+        },
+        {
+          "date": "2025-12-14",
+          "count": 76
+        },
+        {
+          "date": "2025-12-15",
+          "count": 78
+        },
+        {
+          "date": "2025-12-16",
+          "count": 80
+        },
+        {
+          "date": "2025-12-17",
+          "count": 82
+        },
+        {
+          "date": "2025-12-19",
+          "count": 83
+        },
+        {
+          "date": "2025-12-22",
+          "count": 84
+        },
+        {
+          "date": "2025-12-24",
+          "count": 85
+        },
+        {
+          "date": "2025-12-27",
+          "count": 88
+        },
+        {
+          "date": "2025-12-30",
+          "count": 89
+        },
+        {
+          "date": "2026-01-02",
+          "count": 90
+        },
+        {
+          "date": "2026-01-15",
+          "count": 92
+        },
+        {
+          "date": "2026-01-31",
+          "count": 93
+        },
+        {
+          "date": "2026-02-05",
+          "count": 94
+        },
+        {
+          "date": "2026-02-07",
+          "count": 95
+        },
+        {
+          "date": "2026-02-13",
+          "count": 96
+        },
+        {
+          "date": "2026-02-19",
+          "count": 97
+        },
+        {
+          "date": "2026-03-06",
+          "count": 98
+        },
+        {
+          "date": "2026-03-19",
+          "count": 99
+        },
+        {
+          "date": "2026-04-21",
+          "count": 102
+        },
+        {
+          "date": "2026-05-16",
+          "count": 103
+        },
+        {
+          "date": "2026-05-17",
+          "count": 104
+        }
+      ]
+    },
+    "INSTRUMENTATION AND CONTROL ENGINEERING": {
+      "totalOffers": 108,
+      "eligibleStudents": 96,
+      "uniqueStudents": 91,
+      "multipleOffers": 16,
+      "avgCTC": 10.99,
+      "highestCTC": 52,
+      "lowestCTC": 4,
+      "placementPercentage": 94.79,
+      "genderDist": {
+        "Male": 77,
+        "Female": 31
+      },
+      "genderUnique": {
+        "Male": 67,
+        "Female": 24
+      },
+      "ctcBuckets": {
+        "\u003C5": 10,
+        "5-12": 72,
+        "12-20": 18,
+        "20-30": 7,
+        "30-40": 0,
+        "40+": 1
+      },
+      "jobTypeDist": {
+        "FTE": 72,
+        "Intern+PPO": 14,
+        "Intern+FTE": 16,
+        "Intern": 6
+      },
+      "categoryDist": {
+        "SC": 13,
+        "General": 30,
+        "GEN-EWS": 34,
+        "OBC-NCL": 31
+      },
+      "industryDist": {
+        "PSU": 7,
+        "Private": 101
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Reliance Industries Ltd ",
+          "count": 8
+        },
+        {
+          "company": "Hindustan Petroleum Corporation Ltd",
+          "count": 6
+        },
+        {
+          "company": "Sunpharma",
+          "count": 6
+        },
+        {
+          "company": "Global logic ( ELECTRICAL)",
+          "count": 5
+        },
+        {
+          "company": "Sigmoid",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Amazon ",
+          "avgCTC": 52
+        },
+        {
+          "company": "ZScaler ",
+          "avgCTC": 29.5
+        },
+        {
+          "company": "CISCO",
+          "avgCTC": 24.73
+        },
+        {
+          "company": "Oracle",
+          "avgCTC": 21.89
+        },
+        {
+          "company": "Engineer India Limited",
+          "avgCTC": 21
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-07",
+          "count": 6
+        },
+        {
+          "date": "2025-08-12",
+          "count": 7
+        },
+        {
+          "date": "2025-08-13",
+          "count": 8
+        },
+        {
+          "date": "2025-08-19",
+          "count": 9
+        },
+        {
+          "date": "2025-08-20",
+          "count": 10
+        },
+        {
+          "date": "2025-08-25",
+          "count": 11
+        },
+        {
+          "date": "2025-09-02",
+          "count": 12
+        },
+        {
+          "date": "2025-09-30",
+          "count": 24
+        },
+        {
+          "date": "2025-10-10",
+          "count": 29
+        },
+        {
+          "date": "2025-10-13",
+          "count": 35
+        },
+        {
+          "date": "2025-10-15",
+          "count": 43
+        },
+        {
+          "date": "2025-10-23",
+          "count": 44
+        },
+        {
+          "date": "2025-10-27",
+          "count": 45
+        },
+        {
+          "date": "2025-10-30",
+          "count": 47
+        },
+        {
+          "date": "2025-10-31",
+          "count": 48
+        },
+        {
+          "date": "2025-11-19",
+          "count": 50
+        },
+        {
+          "date": "2025-11-20",
+          "count": 52
+        },
+        {
+          "date": "2025-11-21",
+          "count": 54
+        },
+        {
+          "date": "2025-11-22",
+          "count": 59
+        },
+        {
+          "date": "2025-11-25",
+          "count": 62
+        },
+        {
+          "date": "2025-11-26",
+          "count": 65
+        },
+        {
+          "date": "2025-12-02",
+          "count": 66
+        },
+        {
+          "date": "2025-12-09",
+          "count": 68
+        },
+        {
+          "date": "2025-12-11",
+          "count": 71
+        },
+        {
+          "date": "2025-12-12",
+          "count": 75
+        },
+        {
+          "date": "2025-12-14",
+          "count": 76
+        },
+        {
+          "date": "2025-12-16",
+          "count": 77
+        },
+        {
+          "date": "2025-12-18",
+          "count": 78
+        },
+        {
+          "date": "2025-12-19",
+          "count": 79
+        },
+        {
+          "date": "2025-12-23",
+          "count": 81
+        },
+        {
+          "date": "2025-12-27",
+          "count": 85
+        },
+        {
+          "date": "2026-01-03",
+          "count": 86
+        },
+        {
+          "date": "2026-01-09",
+          "count": 87
+        },
+        {
+          "date": "2026-01-15",
+          "count": 88
+        },
+        {
+          "date": "2026-01-16",
+          "count": 91
+        },
+        {
+          "date": "2026-01-17",
+          "count": 92
+        },
+        {
+          "date": "2026-01-21",
+          "count": 94
+        },
+        {
+          "date": "2026-02-10",
+          "count": 95
+        },
+        {
+          "date": "2026-02-19",
+          "count": 96
+        },
+        {
+          "date": "2026-02-25",
+          "count": 98
+        },
+        {
+          "date": "2026-03-18",
+          "count": 99
+        },
+        {
+          "date": "2026-03-24",
+          "count": 102
+        },
+        {
+          "date": "2026-04-23",
+          "count": 103
+        },
+        {
+          "date": "2026-05-06",
+          "count": 105
+        },
+        {
+          "date": "2026-05-14",
+          "count": 107
+        },
+        {
+          "date": "2026-05-28",
+          "count": 108
+        }
+      ]
+    },
+    "CHEMICAL ENGINEERING": {
+      "totalOffers": 75,
+      "eligibleStudents": 74,
+      "uniqueStudents": 63,
+      "multipleOffers": 11,
+      "avgCTC": 10.16,
+      "highestCTC": 116,
+      "lowestCTC": 4.25,
+      "placementPercentage": 85.14,
+      "genderDist": {
+        "Male": 56,
+        "Female": 19
+      },
+      "genderUnique": {
+        "Male": 45,
+        "Female": 18
+      },
+      "ctcBuckets": {
+        "\u003C5": 7,
+        "5-12": 58,
+        "12-20": 9,
+        "20-30": 0,
+        "30-40": 0,
+        "40+": 1
+      },
+      "jobTypeDist": {
+        "FTE": 56,
+        "Intern+FTE": 7,
+        "Intern+PPO": 6,
+        "Intern": 6
+      },
+      "categoryDist": {
+        "OBC-NCL": 29,
+        "SC": 8,
+        "GEN-EWS": 21,
+        "General": 15,
+        "ST": 2
+      },
+      "industryDist": {
+        "Private": 75
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "HPCL-Mittal Energy Limited",
+          "count": 9
+        },
+        {
+          "company": "Honeywell",
+          "count": 8
+        },
+        {
+          "company": "Reliance Industries Ltd ",
+          "count": 6
+        },
+        {
+          "company": "IOL Chemicals and Pharmaceuticals Limited, Barnala, Punjab.",
+          "count": 4
+        },
+        {
+          "company": "Nayara Energy Limited",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Flow Trades Hong Kong Services Ltd. ",
+          "avgCTC": 116
+        },
+        {
+          "company": "Meesho",
+          "avgCTC": 17.5
+        },
+        {
+          "company": "Amazon ",
+          "avgCTC": 15.5
+        },
+        {
+          "company": "Flipkart",
+          "avgCTC": 14.5
+        },
+        {
+          "company": "Mondelez International (FTE)",
+          "avgCTC": 13.81
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-19",
+          "count": 8
+        },
+        {
+          "date": "2025-09-02",
+          "count": 10
+        },
+        {
+          "date": "2025-09-17",
+          "count": 11
+        },
+        {
+          "date": "2025-09-30",
+          "count": 14
+        },
+        {
+          "date": "2025-10-10",
+          "count": 16
+        },
+        {
+          "date": "2025-10-15",
+          "count": 22
+        },
+        {
+          "date": "2025-10-29",
+          "count": 23
+        },
+        {
+          "date": "2025-10-31",
+          "count": 24
+        },
+        {
+          "date": "2025-11-14",
+          "count": 25
+        },
+        {
+          "date": "2025-11-19",
+          "count": 26
+        },
+        {
+          "date": "2025-11-20",
+          "count": 35
+        },
+        {
+          "date": "2025-11-21",
+          "count": 36
+        },
+        {
+          "date": "2025-11-26",
+          "count": 37
+        },
+        {
+          "date": "2025-11-27",
+          "count": 40
+        },
+        {
+          "date": "2025-11-28",
+          "count": 42
+        },
+        {
+          "date": "2025-12-10",
+          "count": 43
+        },
+        {
+          "date": "2025-12-12",
+          "count": 50
+        },
+        {
+          "date": "2025-12-23",
+          "count": 51
+        },
+        {
+          "date": "2025-12-27",
+          "count": 57
+        },
+        {
+          "date": "2026-01-05",
+          "count": 58
+        },
+        {
+          "date": "2026-01-09",
+          "count": 60
+        },
+        {
+          "date": "2026-01-19",
+          "count": 61
+        },
+        {
+          "date": "2026-01-21",
+          "count": 65
+        },
+        {
+          "date": "2026-01-24",
+          "count": 69
+        },
+        {
+          "date": "2026-02-09",
+          "count": 70
+        },
+        {
+          "date": "2026-02-19",
+          "count": 71
+        },
+        {
+          "date": "2026-03-24",
+          "count": 74
+        },
+        {
+          "date": "2026-05-13",
+          "count": 75
+        }
+      ]
+    },
+    "ELECTRICAL ENGINEERING": {
+      "totalOffers": 52,
+      "eligibleStudents": 53,
+      "uniqueStudents": 43,
+      "multipleOffers": 9,
+      "avgCTC": 11.94,
+      "highestCTC": 52,
+      "lowestCTC": 4.25,
+      "placementPercentage": 81.13,
+      "genderDist": {
+        "Female": 11,
+        "Male": 41
+      },
+      "genderUnique": {
+        "Female": 9,
+        "Male": 34
+      },
+      "ctcBuckets": {
+        "\u003C5": 1,
+        "5-12": 33,
+        "12-20": 13,
+        "20-30": 3,
+        "30-40": 0,
+        "40+": 2
+      },
+      "jobTypeDist": {
+        "Intern+PPO": 8,
+        "Intern+FTE": 7,
+        "FTE": 37
+      },
+      "categoryDist": {
+        "General": 18,
+        "GEN-EWS": 10,
+        "OBC-NCL": 15,
+        "ST": 3,
+        "SC": 6
+      },
+      "industryDist": {
+        "Private": 52
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Reliance Industries Ltd ",
+          "count": 4
+        },
+        {
+          "company": "Tredence",
+          "count": 3
+        },
+        {
+          "company": "OPTUM",
+          "count": 3
+        },
+        {
+          "company": "Aditya Birla Management Corporation. Pvt Ltd.",
+          "count": 3
+        },
+        {
+          "company": "ICICI Bank",
+          "count": 2
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Microsoft",
+          "avgCTC": 52
+        },
+        {
+          "company": "Amazon",
+          "avgCTC": 52
+        },
+        {
+          "company": "Oracle",
+          "avgCTC": 21.89
+        },
+        {
+          "company": "UKG (Ultimate Kronos Group)",
+          "avgCTC": 21.62
+        },
+        {
+          "company": "OPTUM",
+          "avgCTC": 19.21
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-19",
+          "count": 1
+        },
+        {
+          "date": "2025-08-25",
+          "count": 2
+        },
+        {
+          "date": "2025-09-01",
+          "count": 3
+        },
+        {
+          "date": "2025-09-02",
+          "count": 5
+        },
+        {
+          "date": "2025-09-30",
+          "count": 16
+        },
+        {
+          "date": "2025-10-10",
+          "count": 18
+        },
+        {
+          "date": "2025-10-15",
+          "count": 22
+        },
+        {
+          "date": "2025-10-18",
+          "count": 23
+        },
+        {
+          "date": "2025-10-27",
+          "count": 24
+        },
+        {
+          "date": "2025-11-11",
+          "count": 25
+        },
+        {
+          "date": "2025-11-13",
+          "count": 26
+        },
+        {
+          "date": "2025-11-17",
+          "count": 27
+        },
+        {
+          "date": "2025-11-20",
+          "count": 29
+        },
+        {
+          "date": "2025-11-21",
+          "count": 30
+        },
+        {
+          "date": "2025-11-22",
+          "count": 32
+        },
+        {
+          "date": "2025-11-26",
+          "count": 33
+        },
+        {
+          "date": "2025-12-09",
+          "count": 35
+        },
+        {
+          "date": "2025-12-12",
+          "count": 36
+        },
+        {
+          "date": "2025-12-16",
+          "count": 38
+        },
+        {
+          "date": "2025-12-17",
+          "count": 39
+        },
+        {
+          "date": "2025-12-23",
+          "count": 40
+        },
+        {
+          "date": "2025-12-27",
+          "count": 41
+        },
+        {
+          "date": "2026-01-16",
+          "count": 44
+        },
+        {
+          "date": "2026-01-24",
+          "count": 46
+        },
+        {
+          "date": "2026-01-27",
+          "count": 47
+        },
+        {
+          "date": "2026-02-05",
+          "count": 48
+        },
+        {
+          "date": "2026-02-09",
+          "count": 49
+        },
+        {
+          "date": "2026-03-03",
+          "count": 51
+        },
+        {
+          "date": "2026-05-06",
+          "count": 52
+        }
+      ]
+    },
+    "MECHANICAL ENGINEERING": {
+      "totalOffers": 114,
+      "eligibleStudents": 100,
+      "uniqueStudents": 95,
+      "multipleOffers": 19,
+      "avgCTC": 8.31,
+      "highestCTC": 20.45,
+      "lowestCTC": 3.78,
+      "placementPercentage": 95,
+      "genderDist": {
+        "Male": 92,
+        "Female": 22
+      },
+      "genderUnique": {
+        "Male": 75,
+        "Female": 20
+      },
+      "ctcBuckets": {
+        "\u003C5": 6,
+        "5-12": 93,
+        "12-20": 14,
+        "20-30": 1,
+        "30-40": 0,
+        "40+": 0
+      },
+      "jobTypeDist": {
+        "Intern+PPO": 18,
+        "FTE": 85,
+        "Intern+FTE": 9,
+        "Intern": 2
+      },
+      "categoryDist": {
+        "GEN-EWS": 26,
+        "General": 34,
+        "SC": 16,
+        "OBC-NCL": 35,
+        "ST": 3
+      },
+      "industryDist": {
+        "Private": 110,
+        "PSU": 4
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Maruti Suzuki India ",
+          "count": 6
+        },
+        {
+          "company": "Jindal Steel Ltd. ",
+          "count": 6
+        },
+        {
+          "company": "HPCL-Mittal Energy Limited",
+          "count": 5
+        },
+        {
+          "company": "Honda Cars India Ltd.",
+          "count": 4
+        },
+        {
+          "company": "Design2Occupancy Services LLP",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Bharat Petroleum Corporation Limited",
+          "avgCTC": 20.45
+        },
+        {
+          "company": "Amazon ",
+          "avgCTC": 15.5
+        },
+        {
+          "company": "Flipkart",
+          "avgCTC": 14.5
+        },
+        {
+          "company": "Future First ",
+          "avgCTC": 14
+        },
+        {
+          "company": "Tata Steel ",
+          "avgCTC": 13.7
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-08-19",
+          "count": 3
+        },
+        {
+          "date": "2025-09-02",
+          "count": 5
+        },
+        {
+          "date": "2025-09-30",
+          "count": 10
+        },
+        {
+          "date": "2025-10-10",
+          "count": 16
+        },
+        {
+          "date": "2025-10-11",
+          "count": 17
+        },
+        {
+          "date": "2025-10-15",
+          "count": 21
+        },
+        {
+          "date": "2025-10-22",
+          "count": 23
+        },
+        {
+          "date": "2025-10-29",
+          "count": 24
+        },
+        {
+          "date": "2025-11-13",
+          "count": 25
+        },
+        {
+          "date": "2025-11-14",
+          "count": 30
+        },
+        {
+          "date": "2025-11-17",
+          "count": 34
+        },
+        {
+          "date": "2025-11-18",
+          "count": 37
+        },
+        {
+          "date": "2025-11-19",
+          "count": 39
+        },
+        {
+          "date": "2025-11-20",
+          "count": 44
+        },
+        {
+          "date": "2025-11-22",
+          "count": 50
+        },
+        {
+          "date": "2025-11-26",
+          "count": 52
+        },
+        {
+          "date": "2025-11-28",
+          "count": 53
+        },
+        {
+          "date": "2025-12-02",
+          "count": 54
+        },
+        {
+          "date": "2025-12-04",
+          "count": 58
+        },
+        {
+          "date": "2025-12-09",
+          "count": 62
+        },
+        {
+          "date": "2025-12-14",
+          "count": 63
+        },
+        {
+          "date": "2025-12-18",
+          "count": 64
+        },
+        {
+          "date": "2025-12-19",
+          "count": 65
+        },
+        {
+          "date": "2025-12-20",
+          "count": 68
+        },
+        {
+          "date": "2025-12-23",
+          "count": 70
+        },
+        {
+          "date": "2025-12-25",
+          "count": 71
+        },
+        {
+          "date": "2025-12-27",
+          "count": 73
+        },
+        {
+          "date": "2025-12-31",
+          "count": 74
+        },
+        {
+          "date": "2026-01-15",
+          "count": 75
+        },
+        {
+          "date": "2026-01-16",
+          "count": 77
+        },
+        {
+          "date": "2026-01-17",
+          "count": 78
+        },
+        {
+          "date": "2026-01-19",
+          "count": 79
+        },
+        {
+          "date": "2026-01-24",
+          "count": 81
+        },
+        {
+          "date": "2026-01-27",
+          "count": 82
+        },
+        {
+          "date": "2026-01-31",
+          "count": 84
+        },
+        {
+          "date": "2026-02-19",
+          "count": 86
+        },
+        {
+          "date": "2026-03-03",
+          "count": 89
+        },
+        {
+          "date": "2026-03-04",
+          "count": 90
+        },
+        {
+          "date": "2026-03-10",
+          "count": 92
+        },
+        {
+          "date": "2026-03-24",
+          "count": 95
+        },
+        {
+          "date": "2026-03-27",
+          "count": 96
+        },
+        {
+          "date": "2026-03-29",
+          "count": 100
+        },
+        {
+          "date": "2026-04-20",
+          "count": 102
+        },
+        {
+          "date": "2026-04-21",
+          "count": 104
+        },
+        {
+          "date": "2026-05-04",
+          "count": 106
+        },
+        {
+          "date": "2026-05-13",
+          "count": 110
+        },
+        {
+          "date": "2026-05-21",
+          "count": 113
+        },
+        {
+          "date": "2026-06-17",
+          "count": 114
+        }
+      ]
+    },
+    "CIVIL ENGINEERING": {
+      "totalOffers": 57,
+      "eligibleStudents": 72,
+      "uniqueStudents": 48,
+      "multipleOffers": 6,
+      "avgCTC": 7.4,
+      "highestCTC": 15.5,
+      "lowestCTC": 3.6,
+      "placementPercentage": 66.67,
+      "genderDist": {
+        "Male": 43,
+        "Female": 14
+      },
+      "genderUnique": {
+        "Male": 34,
+        "Female": 14
+      },
+      "ctcBuckets": {
+        "\u003C5": 8,
+        "5-12": 43,
+        "12-20": 6,
+        "20-30": 0,
+        "30-40": 0,
+        "40+": 0
+      },
+      "jobTypeDist": {
+        "FTE": 34,
+        "Intern+PPO": 14,
+        "Intern+FTE": 5,
+        "Intern": 4
+      },
+      "categoryDist": {
+        "General": 22,
+        "GEN-EWS": 12,
+        "OBC-NCL": 19,
+        "ST": 1,
+        "SC": 3
+      },
+      "industryDist": {
+        "Private": 57
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Larsen & Toubro Ltd.",
+          "count": 8
+        },
+        {
+          "company": "Juniper Green Energy",
+          "count": 3
+        },
+        {
+          "company": "Design2Occupancy Services LLP",
+          "count": 3
+        },
+        {
+          "company": "KEC International ",
+          "count": 3
+        },
+        {
+          "company": "Reliance Industries Ltd ",
+          "count": 2
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Amazon ",
+          "avgCTC": 15.5
+        },
+        {
+          "company": "Future First ",
+          "avgCTC": 14
+        },
+        {
+          "company": "Dyyota Tech Pvt. Ltd.,",
+          "avgCTC": 14
+        },
+        {
+          "company": "OPTUM",
+          "avgCTC": 13.84
+        },
+        {
+          "company": "Optum Computational Engineering",
+          "avgCTC": 13.24
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-09-02",
+          "count": 1
+        },
+        {
+          "date": "2025-09-30",
+          "count": 3
+        },
+        {
+          "date": "2025-10-10",
+          "count": 4
+        },
+        {
+          "date": "2025-10-15",
+          "count": 6
+        },
+        {
+          "date": "2025-10-22",
+          "count": 8
+        },
+        {
+          "date": "2025-11-01",
+          "count": 11
+        },
+        {
+          "date": "2025-11-13",
+          "count": 17
+        },
+        {
+          "date": "2025-11-14",
+          "count": 20
+        },
+        {
+          "date": "2025-11-18",
+          "count": 22
+        },
+        {
+          "date": "2025-11-19",
+          "count": 23
+        },
+        {
+          "date": "2025-11-27",
+          "count": 24
+        },
+        {
+          "date": "2025-11-28",
+          "count": 26
+        },
+        {
+          "date": "2025-12-02",
+          "count": 29
+        },
+        {
+          "date": "2025-12-03",
+          "count": 30
+        },
+        {
+          "date": "2025-12-04",
+          "count": 33
+        },
+        {
+          "date": "2025-12-16",
+          "count": 36
+        },
+        {
+          "date": "2025-12-23",
+          "count": 37
+        },
+        {
+          "date": "2025-12-27",
+          "count": 38
+        },
+        {
+          "date": "2026-01-09",
+          "count": 40
+        },
+        {
+          "date": "2026-01-13",
+          "count": 41
+        },
+        {
+          "date": "2026-01-19",
+          "count": 42
+        },
+        {
+          "date": "2026-01-21",
+          "count": 43
+        },
+        {
+          "date": "2026-02-03",
+          "count": 45
+        },
+        {
+          "date": "2026-02-04",
+          "count": 46
+        },
+        {
+          "date": "2026-02-06",
+          "count": 47
+        },
+        {
+          "date": "2026-02-25",
+          "count": 49
+        },
+        {
+          "date": "2026-03-21",
+          "count": 50
+        },
+        {
+          "date": "2026-04-20",
+          "count": 51
+        },
+        {
+          "date": "2026-04-21",
+          "count": 52
+        },
+        {
+          "date": "2026-04-30",
+          "count": 53
+        },
+        {
+          "date": "2026-05-04",
+          "count": 55
+        },
+        {
+          "date": "2026-06-01",
+          "count": 56
+        },
+        {
+          "date": "2026-06-04",
+          "count": 57
+        }
+      ]
+    },
+    "INDUSTRIAL AND PRODUCTION ENGINEERING": {
+      "totalOffers": 71,
+      "eligibleStudents": 71,
+      "uniqueStudents": 60,
+      "multipleOffers": 11,
+      "avgCTC": 9.07,
+      "highestCTC": 21,
+      "lowestCTC": 3.78,
+      "placementPercentage": 84.51,
+      "genderDist": {
+        "Female": 12,
+        "Male": 59
+      },
+      "genderUnique": {
+        "Female": 10,
+        "Male": 50
+      },
+      "ctcBuckets": {
+        "\u003C5": 9,
+        "5-12": 46,
+        "12-20": 14,
+        "20-30": 2,
+        "30-40": 0,
+        "40+": 0
+      },
+      "jobTypeDist": {
+        "FTE": 47,
+        "Intern+FTE": 9,
+        "Intern+PPO": 12,
+        "Intern": 3
+      },
+      "categoryDist": {
+        "General": 19,
+        "GEN-EWS": 14,
+        "OBC-NCL": 21,
+        "SC": 12,
+        "ST": 5
+      },
+      "industryDist": {
+        "Private": 71
+      },
+      "topCompaniesByCount": [
+        {
+          "company": " Maxop",
+          "count": 6
+        },
+        {
+          "company": "Sunpharma",
+          "count": 5
+        },
+        {
+          "company": "Urban Company",
+          "count": 5
+        },
+        {
+          "company": "JSW",
+          "count": 5
+        },
+        {
+          "company": "Amazon ",
+          "count": 4
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Engineer India Limited",
+          "avgCTC": 21
+        },
+        {
+          "company": "Meesho",
+          "avgCTC": 17.5
+        },
+        {
+          "company": "FNZ Technology (India) Private Limited",
+          "avgCTC": 17
+        },
+        {
+          "company": "Amazon ",
+          "avgCTC": 15.5
+        },
+        {
+          "company": "Flipkart",
+          "avgCTC": 14.5
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-09-04",
+          "count": 1
+        },
+        {
+          "date": "2025-09-30",
+          "count": 3
+        },
+        {
+          "date": "2025-10-13",
+          "count": 8
+        },
+        {
+          "date": "2025-10-22",
+          "count": 13
+        },
+        {
+          "date": "2025-10-29",
+          "count": 18
+        },
+        {
+          "date": "2025-10-31",
+          "count": 19
+        },
+        {
+          "date": "2025-11-06",
+          "count": 21
+        },
+        {
+          "date": "2025-11-14",
+          "count": 22
+        },
+        {
+          "date": "2025-11-19",
+          "count": 26
+        },
+        {
+          "date": "2025-11-21",
+          "count": 27
+        },
+        {
+          "date": "2025-11-28",
+          "count": 29
+        },
+        {
+          "date": "2025-12-02",
+          "count": 31
+        },
+        {
+          "date": "2025-12-11",
+          "count": 33
+        },
+        {
+          "date": "2025-12-12",
+          "count": 34
+        },
+        {
+          "date": "2025-12-18",
+          "count": 35
+        },
+        {
+          "date": "2026-01-09",
+          "count": 37
+        },
+        {
+          "date": "2026-01-14",
+          "count": 38
+        },
+        {
+          "date": "2026-01-15",
+          "count": 39
+        },
+        {
+          "date": "2026-01-24",
+          "count": 42
+        },
+        {
+          "date": "2026-02-06",
+          "count": 43
+        },
+        {
+          "date": "2026-02-19",
+          "count": 44
+        },
+        {
+          "date": "2026-02-24",
+          "count": 45
+        },
+        {
+          "date": "2026-03-02",
+          "count": 46
+        },
+        {
+          "date": "2026-03-04",
+          "count": 47
+        },
+        {
+          "date": "2026-03-12",
+          "count": 48
+        },
+        {
+          "date": "2026-03-29",
+          "count": 49
+        },
+        {
+          "date": "2026-04-20",
+          "count": 54
+        },
+        {
+          "date": "2026-04-21",
+          "count": 58
+        },
+        {
+          "date": "2026-05-04",
+          "count": 61
+        },
+        {
+          "date": "2026-05-14",
+          "count": 63
+        },
+        {
+          "date": "2026-05-21",
+          "count": 69
+        },
+        {
+          "date": "2026-06-01",
+          "count": 70
+        },
+        {
+          "date": "2026-06-02",
+          "count": 71
+        }
+      ]
+    },
+    "BIO TECHNOLOGY": {
+      "totalOffers": 20,
+      "eligibleStudents": 31,
+      "uniqueStudents": 18,
+      "multipleOffers": 2,
+      "avgCTC": 7.46,
+      "highestCTC": 14,
+      "lowestCTC": 4,
+      "placementPercentage": 58.06,
+      "genderDist": {
+        "Male": 10,
+        "Female": 10
+      },
+      "genderUnique": {
+        "Male": 10,
+        "Female": 8
+      },
+      "ctcBuckets": {
+        "\u003C5": 9,
+        "5-12": 9,
+        "12-20": 2,
+        "20-30": 0,
+        "30-40": 0,
+        "40+": 0
+      },
+      "jobTypeDist": {
+        "Intern+FTE": 5,
+        "Intern+PPO": 6,
+        "FTE": 3,
+        "Intern": 6
+      },
+      "categoryDist": {
+        "General": 7,
+        "OBC-NCL": 8,
+        "GEN-EWS": 3,
+        "SC": 2
+      },
+      "industryDist": {
+        "Private": 20
+      },
+      "topCompaniesByCount": [
+        {
+          "company": "Addictive Learning Technologies LTD",
+          "count": 4
+        },
+        {
+          "company": "Guangdong Academy of Agricultural Sciences ",
+          "count": 1
+        },
+        {
+          "company": "Sunpharma",
+          "count": 1
+        },
+        {
+          "company": "EXL",
+          "count": 1
+        },
+        {
+          "company": "Innovaccer",
+          "count": 1
+        }
+      ],
+      "topCompaniesByAvgCTC": [
+        {
+          "company": "Innovaccer",
+          "avgCTC": 14
+        },
+        {
+          "company": "Guangdong Academy of Agricultural Sciences ",
+          "avgCTC": 12
+        },
+        {
+          "company": "Sunpharma",
+          "avgCTC": 8
+        },
+        {
+          "company": "Mindseekers Technologies Pvt. Ltd.!",
+          "avgCTC": 8
+        },
+        {
+          "company": "EXL",
+          "avgCTC": 7.5
+        }
+      ],
+      "offersVsDate": [
+        {
+          "date": "2025-10-02",
+          "count": 1
+        },
+        {
+          "date": "2025-10-13",
+          "count": 2
+        },
+        {
+          "date": "2025-10-31",
+          "count": 3
+        },
+        {
+          "date": "2025-11-25",
+          "count": 4
+        },
+        {
+          "date": "2025-12-10",
+          "count": 5
+        },
+        {
+          "date": "2025-12-19",
+          "count": 6
+        },
+        {
+          "date": "2025-12-24",
+          "count": 7
+        },
+        {
+          "date": "2025-12-27",
+          "count": 11
+        },
+        {
+          "date": "2026-01-15",
+          "count": 13
+        },
+        {
+          "date": "2026-01-19",
+          "count": 14
+        },
+        {
+          "date": "2026-02-04",
+          "count": 15
+        },
+        {
+          "date": "2026-02-05",
+          "count": 16
+        },
+        {
+          "date": "2026-02-19",
+          "count": 17
+        },
+        {
+          "date": "2026-03-02",
+          "count": 18
+        },
+        {
+          "date": "2026-03-29",
+          "count": 19
+        },
+        {
+          "date": "2026-06-01",
+          "count": 20
+        }
+      ]
+    }
+  }
+}

--- a/assets/companies2026.md
+++ b/assets/companies2026.md
@@ -1,0 +1,173 @@
+Company Process Time In Time Out Visit Status Status Branches CTC 1 January 2026
+No events 2 January 2026 Vanco.ai PPT 12:00PM 12:45PM Online Confirmed All
+B.Tech 25K or 6to 8 LPA 3 January 2026 No events 4 January 2026 Sunday 5 January
+2026 Accenture Interview 9AM 9PM Online Confirmed B.Tech ALL 12 or 35K 6 January
+2026 Ambient Scientific Online Test 9AM 9PM Online Test Confirmed B.Tech &
+M.Tech CSE, ECE, IT,EE, ICE 6.5 7 January 2026 No events 8 January 2026
+Cubasation Online Test / Interveiw 9AM 9PM Online Test Confirmed CSE, IT,
+ECE,EEand ICE 7.72 LPA 9 January 2026 No events 10 January 2026 No events 11
+January 2026 Sunday 12 January 2026 Aditya Birla Test 6PM 9PM Online Test
+Confirmed ME, EE, IP, TT & ICE 7.50 13 January 2026 No events 14 January 2026 No
+events 15 January 2026 Reliance Consumer Interview 9AM 9PM Visit Confirmed IPE,
+ME, EE, ICE 7.50 16 January 2026 Aditya Birla GD& Interview 9:00AM Visit
+Confirmed Btech ME IP TT EE ICE 7 17 January 2026 Reliance Consumer Interview
+9AM 9PM Visit Confirmed ME, EE, ICE 7.50 18 January 2026 Sunday 19 January 2026
+Insurance dekho Full process 9:00AM On hold Postponed BTech circuital 8.5
+Reliance Online Test 3PM 6PM Online (CCLabs) Confirmed B.TEch 3rd year 30K 20
+January 2026 Aarti Industries Full Process 9AM 9 PM Visit Not Confirm yet Core
+Branches 5.5 Accenture Online Test 9AM 9PM Visit Confirmed All Branches 50K 21
+January 2026 Accenture Online Test 9AM 9PM Visit Confirmed All Branches 50K
+Nayara Energy Written Test & Interview 9AM 9PM Visit Confirmed Civil , EE, ICE &
+ME 8.50 22 January 2026 Nayara Energy Written Test & Interview 9AM 9PM Visit
+Confirmed Civil , EE, ICE & ME 8.50 23 January 2026 Trident Group Online Test &
+Interview 9AM 9PM Visit Confirmed ME, TT, CHE, EE & IPE 12 24 January 2026 Tata
+Steel Interview 9AM 9PM Visit Confirmed ME 13+ 25 January 2026 Sunday 26 January
+2026 Republic Day (Holiday) 27 January 2026 Avanti Full Process 9:00AM Visit
+Confirmed MSC 7 28 January 2026 Square corporation Full process 9:00 AM Visit
+Postponed Mba Btech TT, IPE,ME,IT 4.2 Avanti Full Process 9:00AM Visit Confirmed
+MSC 7 NISG Interviews 9:00AM Online Confirmed CSE 20 29 January 2026 Meddibudddy
+Interview 9:00AM Online Confirmed ALL BTech 6 30 January 2026 Exam (Jai Hind) 31
+January 2026 Exam Jai HindDate Company Process Time In Time Out Visit Status
+Status Branches CTC 1 December 2025 Exam 2 December 2025 Infosys OA 9:00AM Visit
+confirmed BTech Circuital 6.5-11 3 December 2025 Exam 4 December 2025 Tetra Pak
+Interview 9AM 9PM Visit Confirmed ICE 8 Fidelity International PPT 3PM 4PM
+Online Confirmed CSE and IT 9 Jade solution OA 10:00 AM Visit Confirmed Btech
+(Circuital) 8 TT CONSULTANTS Full process Online Confirmed Btech ECE/ME MTECH
+spml/vlsi/De 7 5 December 2025 Exam 6 December 2025 JSL Full Process 9AM 9PM
+Visit Confirmed ME, EE & ICE 8 Tynor Full Process 9AM Visit Confirmed Textile 5
+Fidelity International Online Test 10AM 1:00PM Online Confirmed CSE & IT 9 7
+December 2025 Sunday 8 December 2025 JSS University, Noida. Full Process 9AM 2PM
+Visit Confirmed MTech (Circutial) 8.25 APPforbharat PPT 6AM Onwards Visit
+Confirmed CSE, IT 35K (10LPA) 9 December 2025 Fidelity International Interview
+9AM 5PM Online Confirmed CSE and IT 9 10 December 2025 UPL Data Science Online
+Test 9AM 9PM Not Confirmed TBA CSE,IT,ME,CHE,ICE, EE, ECE 17 Kuantum Papers
+written Test & Interview 9AM 9PM Visit Confirmed CHE & ICE 5 Infosys Interview 9
+AM Chandigarh DC Confirmed Shortlisted candidates 6.5-21 11 December 2025
+Fidelity International Interview 9AM 5PM Online Confirmed CSE and IT 9 UPL Data
+Science Interview 9AM 9PM Online Confirmed CSE,IT,ME,CHE,ICE, EE, ECE 17 SLB
+Private Interview 9PM 9PM Online Confirmed ME 10.55 Samsung R&D Online Test 12PM
+Onwards Visit Confirmed Mtech CSE and IT 50K 12 December 2025 Samsung R&D
+Interview 9AM 9PM Visit Confirmed MTEch CSE and IT 50K JADE SOLUTION Interview
+9AM 9PM Visit Confirmed Circuital 8 13 December 2025 Jade Gloabal Interview 9AM
+9PM Visit Confirmed CSE,IT,ECE,EE and ICE 8 (20K) National Institute for Smart
+Government Online Test 9am 9pm Online Confirmed CSE, ECE & IT 20 14 December
+2025 Jade Gloabal Interview 9AM 9PM Visit Confirmed CSE,IT,ECE,EE and ICE 8
+(20K) Presidencyuniversity Interview 9AM 9PM Visit Confirmed M.Tech All 10.82 15
+December 2025 Mphasis PPT 9AM 9PM Online Confirmed CSE,ECE,IT,EE,ICE 6 FNZ
+Interview 9AM 9PM Online Confirmed ALL Branches 17 KEC International Interview
+10AM Onwards Online Confirmed Civil and EE 16 December 2025 Tata Steel Technical
+Test 9AM 9PM Online Confirmed ME 13.87 BPCL Test 9AM 9PM Visit Confirmed ME,ICE,
+CHE,CSE,EE & Civil 20 Pathlock Full Process 9 AM 9 PM Visit Confirmed BTECH
+(CIRCUITAL) MTECH(CS/IS/AI/MIA) 24 17 December 2025 BEL Full Process 9AM 9PM
+Visit Confirmed ECE & ME 12.50 Mphasis Online Test 9AM Onwards Online Confirmed
+CSE,ECE,IT,EE,ICE 6 BPCL Interview 9AM 9PM Visit Confirmed ME,ICE, CHE,CSE,EE &
+Civil 20 18 December 2025 Tata Steel Cultural Appreciation Test 9AM 9PM Online
+Confirmed ME 13.87 Keysights Online test 10AM Onwards Online Confirmed
+CSE,IT,ECE,EE and ICE 40 to 60K 19 December 2025 NBC Bearing Interview 9AM 9PM
+Visit Confirmed ME, IPE & ECE 5.5 Mphasis Interview 9AM Onwards Online Confirmed
+CSE,ECE,IT,EE,ICE 6 Nayara Energy Full Process 9AM Onwards Visit Confirmed 9 20
+December 2025 No events 21 December 2025 Sunday 22 December 2025 Sanoffi Full
+Process 9AM 9PM Visit Confirmed CSE and IT 23 December 2025 Sanoffi Full Process
+9AM 9PM Visit Confirmed CSE and IT 24 December 2025 MAQ Software Online Test 9AM
+9PM Online Confirmed CSE & IT 9 25 December 2025 No events 26 December 2025 No
+events 27 December 2025 No events 28 December 2025 Sunday 29 December 2025 Tata
+Steel GD and PI 9AM VISIT CONFIRMED Btech ME 13.87 30 December 2025 RELIANCE
+CONSUMER PI 9AM VISIT Confirmed ME BTECH 13.87 31 December 2025 No events Date
+Company Process Time In Time Out Visit Status Status Branches CTC 1 November
+2025 No events 2 November 2025 Sunday 3 November 2025 No events 4 November 2025
+No events 5 November 2025 No events 6 November 2025 No events 7 November 2025 No
+events 8 November 2025 No events 9 November 2025 Sunday 10 November 2025 No
+events 11 November 2025 IBM Interview 9 AM 9 PM Online Confirmed
+CSE,ECE,IT,EE,ICE 11 12 November 2025 Maruti Suzuki Online Test 1 PM 11 PM
+Online Confirmed ME,EE,IT,CSE 9.56 Honda Cars Interview 9 AM 7 PM Visit
+Confirmed EE,ME,IPE 6 Accenture Interview 9 AM 9 PM Online Confirmed All
+Branches 11.89 (10.89+1) 13 November 2025 Bharti Airtel Online Test 10 AM 12:30
+PM Online Confirmed CSE,ECE,IT,EE,ICE 14.75 Yamaha PPT & Online Test 9 AM 4 PM
+Visit Confirmed IPE 7.50 Hevells Online Test 5 PM 7 PM Online Confirmed
+CSE,IT,ECE,ICE,EE 10 Incubyte PPT 6 PM 7 PM Online Confirmed CSE,ECE,IT,EE,ICE
+6-8 14 November 2025 Yamaha Interview 9 AM 6 PM Visit Confirmed IPE 7.50
+Sunpharma Online Test 9 AM 6 PM Online Confirmed CHE,ME,ICE 8 15 November 2025
+Sunpharma Interview 9 AM 6 PM Online Confirmed CHE,ME,ICE 8 ITC Limited (Intern
+2m) Online Test 9 AM 6 PM Online Confirmed ME 50K 16 November 2025 Sunday 17
+November 2025 Sunpharma Online Test 9AM 9PM Online Confirmed ICE 8 18 November
+2025 Sunpharma Interview 9AM 9PM Online Confirmed ICE 8 19 November 2025 HMEL GD
+& Interview 9 AM 9 PM Visit Confirmed CHE,ME,ICE,EE 9.20 Havells Interview 9AM
+9PM Online Confirmed CSE,ECE,IT,EE,ICE 10 Globallogic Full Process 9AM 3PM
+Online Confirmed ICE & EE 8 20 November 2025 HMEL Interview 9 AM 9 PM Visit
+Confirmed CHE,ME,ICE,EE 9.20 Mondelez Full Process 9 AM 9 PM Visit Confirmed
+ME,IPE,CHE,ECE,ICE,EE 13.81 Havells Interview 10AM 5PM Online Confirmed
+CSE,ECE,IT,EE,ICE 10 Innovaccer online Test 10AM 1PM Online Not Confirmed All
+Branches 14 21 November 2025 Inox India Full Process 9 AM 9 PM Visit Confirmed
+CHE,ICE,EE,ME 4.25 Samsung SRI Full Process 9 AM 9 PM Visit Confirmed
+CSE,ECE,IT,EE 15.50 Aakash Institute Online test 12pm Onwards Online Confirmed
+All Btech mtech msc 7.25 22 November 2025 Innovaccer Interview 9 AM 9 PM Visit
+Confirmed All Branches 12 and 14 23 November 2025 Sunday 24 November 2025 Airtel
+Interview 9AM 9 PM Online Confirmed CSE,ECE,IT,EE,ICE 14.75 JSL Interview 9AM
+9PM Visit TBA Suzuki motors PPT 2PM Onwards Online Confirmed Civil, ME, EE & IPE
+7.70 25 November 2025 Amantya Technology Full Process 9 AM 9 PM Visit Confirmed
+CSE,IT or ECE 6 26 November 2025 Punjab Chemical & Corp Full Process 9 AM 9 PM
+Visit Confirmed CHE 5.50 Mphasis PPT 10AM 12PM Online Confirmed
+CSE,ECE,IT,EE,ICE 6 27 November 2025 V A Tech Wabag Full Process 9AM 9PM Visit
+Confirmed CHE, EE,ME, IPE,Civil,Stru,ICE 5 Mphasis Online Test 9AM 9PM Online
+Not Confirmed CSE,ECE,IT,EE,ICE 6 Amantya Technology Full Process 9 AM 9 PM
+Visit Confirmed CSE,ECE,IT 6 28 November 2025 Design2Occupancy Services LLP Full
+Process 9AM 9PM Visit Confirmed Civil, ME and EE 5 Square Corporation Full
+Process 9AM 9PM Visit Confirmed TT & IPE 4.20 Reliance Consumer Products Limited
+Full Process 9AM 9PM Visit Confirmed EE, ME & ICE 8 Siriusai Online Test 3PM
+Onwards Online Confirmed CSE,ECE,IT,EE,ICE 11.80 29 November 2025 Mphasis
+Interview 9AM 9PM Online Wabag CSE,ECE,IT,EE,ICE 6 30 November 2025 Sunday
+Developed by Placement Portal Dev TeamDate Company Process Time In Time Out
+Visit Status Status Branches CTC 1 February 2026 Sunday 2 February 2026 Vanco.ai
+PPT 12:00PM 12:45PM Online Confirmed All B.Tech 25K & (6 to 8 )CTC 3 February
+2026 No events 4 February 2026 PeopleStrong Full Process 9AM 9PM Visit Confirmed
+ECE,CSE,IT,ICE & EE 50K & 8 LPA 5 February 2026 Alstom Group Session Visit
+Confirmed All B.Tech and M.Tech Accenture Interview 9AM 9PM Online Confirmed All
+B.Tech & MTech 35K & 12 LPA 6 February 2026 Ambient Scientific Online Test 9AM
+9PM Online Test Confirmed B.Tech & M.Tech CSE, ECE, IT,EE, ICE 6.5 LPA Ambition
+Institute, Hisar. Full Process 9AM 9PM Visit Not Confirmed M.Tech & MSc 6 fix &
+4 Variable -10 LPA 7 February 2026 No events 8 February 2026 Sunday 9 February
+2026 Fedility Full Process 9:00 AM Online Conifrmed CSE, IT,ECE,DS,VLSI 35K
+Insurance Dekho Full Process 9AM 9PM Visit Confirmed CSE, ECE, IT, ICE and EE
+8.50 LPA 10 February 2026 No events 11 February 2026 No events 12 February 2026
+No events 13 February 2026 Medibuddy Interview 9AM 9PM Online Confirmed All
+B.Tech 6 14 February 2026 No events 15 February 2026 Sunday 16 February 2026
+square-corp Full Process 9AM 9PM Visit Confirmed TT & IPE 35K per month Rubber
+Neelkanth Full Process 9AM 9PM Visit Confirmed IPE ME & CHE 20K to 25K 17
+February 2026 No events 18 February 2026 No events 19 February 2026 No events 20
+February 2026 No events 21 February 2026 No events 22 February 2026 Sunday 23
+February 2026 No events 24 February 2026 Gladify PPT and Test 3PM Onwards Online
+Confirmed All branches 4-6 LPA 25 February 2026 Reliance Online Test 10AM 1PM
+Online but in Lab Confirmed Civil 30K (Summer Intern) 26 February 2026 Ralson
+Ludhiana Interview 10AM 5PM Visit Confirmed CHE & ME < IPE 5.5 LPA 27 February
+2026 Aditya Birla Interview 10AM 5PM Visit Confirmed TT 20K (Internship) 28
+February 2026 No events Developed by Placement Portal Dev TeamDate Company
+Process Time In Time Out Visit Status Status Branches CTC 1 March 2026 Sunday 2
+March 2026 Tata Power Interview 9AM 3PM Online Confirmed EE 8.50 Jubilant Food
+Works Interview 6PM 10PM Online Confirmed ICE, ME, IP, ME 8 Shri ram Sugar Mill
+PPT 11AM 12PM Online Confirmed All Mtech 7 Vedanta Group Interview 3PM Onwards
+Online Confirmed ICE 12 3 March 2026 Holi (Holiday) 4 March 2026 Vedanta Group
+Interview 9AM 6PM Online CHE, ME and ICE 9 Vardhman Interview 9AM 6PM Online
+Confirmed MBA 5.5 NPCI Online Test 11AM 3PM Online Confirmed B.Tech all
+Circuital 35K 5 March 2026 Shriram Finace Interview 10Am 4PM Online All B.Tech
+and MBA 6 Travclan Online Test 10AM 2PM Online CSE, IT, ECE, EE, ICE 6-9 LPA DCM
+Shri Ram Sugar Mill Online Test 10AM 1PM Online Confirmed M.Tech All 8 6 March
+2026 Aditya Fashion Interview 3PM 6Pm Visit Confirmed TT 30K Shriram Finance
+Interview 10AM 6PM Online Confirmed All B.Tech and MBA 6 LPA 7 March 2026
+Morephan Labotories Full Process 9AM 9PM Visit Confirmed BT, ME and CHE 24K Per
+month 8 March 2026 Sunday 9 March 2026 Exams 10 March 2026 No events 11 March
+2026 No events 12 March 2026 No events 13 March 2026 No events 14 March 2026 No
+events 15 March 2026 Sunday 16 March 2026 No events 17 March 2026 ColorJet India
+Limited Interview 10AM 1PM Online Confirmed TT 5 18 March 2026 No events 19
+March 2026 Kaizen GD 9AM 9PM Online Confirmed IPE 5.75 20 March 2026 Jindal
+Steel Full Process 9AM 9PM Visit CHE,ME, Civil, EE, ECE, ICE and IPE 10 LPA
+Vedanta Group Interview 9AM 9PM Online Confirmed ME, CHE & ICE 8 21 March 2026
+Morephan Labotories Full Process 9AM Visit Date not confirmed BT, ME and CHE 24K
+Per Month 22 March 2026 Sunday 23 March 2026 IBM Group Interview 9AM 9PM Visit
+not confirmed yet CSE,IT 8.25 LPA UST AI & Technology Not Confirmed Yet CSE,
+ECE, IT (B.Tech & M.Tech) 12 24 March 2026 WebTech Interviews 9AM 9PM Online
+CSE,ICE,ECE,IT, DS, AI, etc. 35K Per Month 25 March 2026 Tata Power Interview
+9AM 9PM Visit Not Confirmed Yet CSE/IT 9 26 March 2026 Blacklead Infratech
+Private Limited Not Confirmed Yet Civil 30K Per Month fixed 27 March 2026
+Delhivery Interviews Online Not Confirmed Yet MBA 6 28 March 2026 No events 29
+March 2026 Sunday 30 March 2026 No events 31 March 2026 No events Developed by
+Placement Portal Dev Team

--- a/assets/redditPosts/company_visits_december_2025.md
+++ b/assets/redditPosts/company_visits_december_2025.md
@@ -1,0 +1,26 @@
+# NITJ Company Recruitment Visits & Schedules - December 2025
+
+Below is the list of companies visiting, online tests, interviews, and packages for **December 2025**:
+
+| Date | Event Details / Company / CTC / Eligible Branches |
+| :--- | :--- |
+| 2 December 2025 | Infosys OA 9:00AM Visit confirmed BTech Circuital 6.5-11 |
+| 4 December 2025 | Tetra Pak Interview 9AM 9PM Visit Confirmed ICE 8 Fidelity International PPT 3PM 4PM Online Confirmed CSE and IT 9 Jade solution OA 10:00 AM Visit Confirmed Btech (Circuital) 8 TT CONSULTANTS Full process Online Confirmed Btech ECE/ME MTECH spml/vlsi/De 7 |
+| 6 December 2025 | JSL Full Process 9AM 9PM Visit Confirmed ME, EE & ICE 8 Tynor Full Process 9AM Visit Confirmed Textile 5 Fidelity International Online Test 10AM 1:00PM Online Confirmed CSE & IT 9 |
+| 8 December 2025 | JSS University, Noida. Full Process 9AM 2PM Visit Confirmed MTech (Circutial) 8.25 APPforbharat PPT 6AM Onwards Visit Confirmed CSE, IT 35K (10LPA) |
+| 9 December 2025 | Fidelity International Interview 9AM 5PM Online Confirmed CSE and IT 9 |
+| 10 December 2025 | UPL Data Science Online Test 9AM 9PM Not Confirmed TBA CSE,IT,ME,CHE,ICE, EE, ECE 17 Kuantum Papers written Test & Interview 9AM 9PM Visit Confirmed CHE & ICE 5 Infosys Interview 9 AM Chandigarh DC Confirmed Shortlisted candidates 6.5-21 |
+| 11 December 2025 | Fidelity International Interview 9AM 5PM Online Confirmed CSE and IT 9 UPL Data Science Interview 9AM 9PM Online Confirmed CSE,IT,ME,CHE,ICE, EE, ECE 17 SLB Private Interview 9PM 9PM Online Confirmed ME 10.55 Samsung R&D Online Test 12PM Onwards Visit Confirmed Mtech CSE and IT 50K |
+| 12 December 2025 | Samsung R&D Interview 9AM 9PM Visit Confirmed MTEch CSE and IT 50K JADE SOLUTION Interview 9AM 9PM Visit Confirmed Circuital 8 |
+| 13 December 2025 | Jade Gloabal Interview 9AM 9PM Visit Confirmed CSE,IT,ECE,EE and ICE 8 (20K) National Institute for Smart Government Online Test 9am 9pm Online Confirmed CSE, ECE & IT 20 |
+| 14 December 2025 | Jade Gloabal Interview 9AM 9PM Visit Confirmed CSE,IT,ECE,EE and ICE 8 (20K) Presidencyuniversity Interview 9AM 9PM Visit Confirmed M.Tech All 10.82 |
+| 15 December 2025 | Mphasis PPT 9AM 9PM Online Confirmed CSE,ECE,IT,EE,ICE 6 FNZ Interview 9AM 9PM Online Confirmed ALL Branches 17 KEC International Interview 10AM Onwards Online Confirmed Civil and EE |
+| 16 December 2025 | Tata Steel Technical Test 9AM 9PM Online Confirmed ME 13.87 BPCL Test 9AM 9PM Visit Confirmed ME,ICE, CHE,CSE,EE & Civil 20 Pathlock Full Process 9 AM 9 PM Visit Confirmed BTECH (CIRCUITAL) MTECH(CS/IS/AI/MIA) 24 |
+| 17 December 2025 | BEL Full Process 9AM 9PM Visit Confirmed ECE & ME 12.50 Mphasis Online Test 9AM Onwards Online Confirmed CSE,ECE,IT,EE,ICE 6 BPCL Interview 9AM 9PM Visit Confirmed ME,ICE, CHE,CSE,EE & Civil 20 |
+| 18 December 2025 | Tata Steel Cultural Appreciation Test 9AM 9PM Online Confirmed ME 13.87 Keysights Online test 10AM Onwards Online Confirmed CSE,IT,ECE,EE and ICE 40 to 60K |
+| 19 December 2025 | NBC Bearing Interview 9AM 9PM Visit Confirmed ME, IPE & ECE 5.5 Mphasis Interview 9AM Onwards Online Confirmed CSE,ECE,IT,EE,ICE 6 Nayara Energy Full Process 9AM Onwards Visit Confirmed 9 |
+| 22 December 2025 | Sanoffi Full Process 9AM 9PM Visit Confirmed CSE and IT |
+| 23 December 2025 | Sanoffi Full Process 9AM 9PM Visit Confirmed CSE and IT |
+| 24 December 2025 | MAQ Software Online Test 9AM 9PM Online Confirmed CSE & IT 9 |
+| 29 December 2025 | Tata Steel GD and PI 9AM VISIT CONFIRMED Btech ME 13.87 |
+| 30 December 2025 | RELIANCE CONSUMER PI 9AM VISIT Confirmed ME BTECH 13.87 |

--- a/assets/redditPosts/company_visits_february_2026.md
+++ b/assets/redditPosts/company_visits_february_2026.md
@@ -1,0 +1,17 @@
+# NITJ Company Recruitment Visits & Schedules - February 2026
+
+Below is the list of companies visiting, online tests, interviews, and packages for **February 2026**:
+
+| Date | Event Details / Company / CTC / Eligible Branches |
+| :--- | :--- |
+| 2 February 2026 | Vanco.ai PPT 12:00PM 12:45PM Online Confirmed All B.Tech 25K & (6 to 8 )CTC |
+| 4 February 2026 | PeopleStrong Full Process 9AM 9PM Visit Confirmed ECE,CSE,IT,ICE & EE 50K & 8 LPA |
+| 5 February 2026 | Alstom Group Session Visit Confirmed All B.Tech and M.Tech Accenture Interview 9AM 9PM Online Confirmed All B.Tech & MTech 35K & 12 LPA |
+| 6 February 2026 | Ambient Scientific Online Test 9AM 9PM Online Test Confirmed B.Tech & M.Tech CSE, ECE, IT,EE, ICE 6.5 LPA Ambition Institute, Hisar. Full Process 9AM 9PM Visit Not Confirmed M.Tech & MSc 6 fix & 4 Variable -10 LPA |
+| 9 February 2026 | Fedility Full Process 9:00 AM Online Conifrmed CSE, IT,ECE,DS,VLSI 35K Insurance Dekho Full Process 9AM 9PM Visit Confirmed CSE, ECE, IT, ICE and EE 8.50 LPA |
+| 13 February 2026 | Medibuddy Interview 9AM 9PM Online Confirmed All B.Tech 6 |
+| 16 February 2026 | square-corp Full Process 9AM 9PM Visit Confirmed TT & IPE 35K per month Rubber Neelkanth Full Process 9AM 9PM Visit Confirmed IPE ME & CHE 20K to 25K |
+| 24 February 2026 | Gladify PPT and Test 3PM Onwards Online Confirmed All branches 4-6 LPA |
+| 25 February 2026 | Reliance Online Test 10AM 1PM Online but in Lab Confirmed Civil 30K (Summer Intern) |
+| 26 February 2026 | Ralson Ludhiana Interview 10AM 5PM Visit Confirmed CHE & ME < IPE 5.5 LPA |
+| 27 February 2026 | Aditya Birla Interview 10AM 5PM Visit Confirmed TT 20K (Internship) |

--- a/assets/redditPosts/company_visits_january_2026.md
+++ b/assets/redditPosts/company_visits_january_2026.md
@@ -1,0 +1,23 @@
+# NITJ Company Recruitment Visits & Schedules - January 2026
+
+Below is the list of companies visiting, online tests, interviews, and packages for **January 2026**:
+
+| Date | Event Details / Company / CTC / Eligible Branches |
+| :--- | :--- |
+| 2 January 2026 | Vanco.ai PPT 12:00PM 12:45PM Online Confirmed All B.Tech 25K or 6to 8 LPA |
+| 5 January 2026 | Accenture Interview 9AM 9PM Online Confirmed B.Tech ALL 12 or 35K |
+| 6 January 2026 | Ambient Scientific Online Test 9AM 9PM Online Test Confirmed B.Tech & M.Tech CSE, ECE, IT,EE, ICE 6.5 |
+| 8 January 2026 | Cubasation Online Test / Interveiw 9AM 9PM Online Test Confirmed CSE, IT, ECE,EEand ICE 7.72 LPA |
+| 12 January 2026 | Aditya Birla Test 6PM 9PM Online Test Confirmed ME, EE, IP, TT & ICE 7.50 |
+| 15 January 2026 | Reliance Consumer Interview 9AM 9PM Visit Confirmed IPE, ME, EE, ICE 7.50 |
+| 16 January 2026 | Aditya Birla GD& Interview 9:00AM Visit Confirmed Btech ME IP TT EE ICE 7 |
+| 17 January 2026 | Reliance Consumer Interview 9AM 9PM Visit Confirmed ME, EE, ICE 7.50 |
+| 19 January 2026 | Insurance dekho Full process 9:00AM On hold Postponed BTech circuital 8.5 Reliance Online Test 3PM 6PM Online (CCLabs) Confirmed B.TEch 3rd year 30K |
+| 20 January 2026 | Aarti Industries Full Process 9AM 9 PM Visit Not Confirm yet Core Branches 5.5 Accenture Online Test 9AM 9PM Visit Confirmed All Branches 50K |
+| 21 January 2026 | Accenture Online Test 9AM 9PM Visit Confirmed All Branches 50K Nayara Energy Written Test & Interview 9AM 9PM Visit Confirmed Civil , EE, ICE & ME 8.50 |
+| 22 January 2026 | Nayara Energy Written Test & Interview 9AM 9PM Visit Confirmed Civil , EE, ICE & ME 8.50 |
+| 23 January 2026 | Trident Group Online Test & Interview 9AM 9PM Visit Confirmed ME, TT, CHE, EE & IPE 12 |
+| 24 January 2026 | Tata Steel Interview 9AM 9PM Visit Confirmed ME 13+ |
+| 27 January 2026 | Avanti Full Process 9:00AM Visit Confirmed MSC 7 |
+| 28 January 2026 | Square corporation Full process 9:00 AM Visit Postponed Mba Btech TT, IPE,ME,IT 4.2 Avanti Full Process 9:00AM Visit Confirmed MSC 7 NISG Interviews 9:00AM Online Confirmed CSE 20 |
+| 29 January 2026 | Meddibudddy Interview 9:00AM Online Confirmed ALL BTech 6 |

--- a/assets/redditPosts/company_visits_march_2026.md
+++ b/assets/redditPosts/company_visits_march_2026.md
@@ -1,0 +1,20 @@
+# NITJ Company Recruitment Visits & Schedules - March 2026
+
+Below is the list of companies visiting, online tests, interviews, and packages for **March 2026**:
+
+| Date | Event Details / Company / CTC / Eligible Branches |
+| :--- | :--- |
+| 2 March 2026 | Tata Power Interview 9AM 3PM Online Confirmed EE 8.50 Jubilant Food Works Interview 6PM 10PM Online Confirmed ICE, ME, IP, ME 8 Shri ram Sugar Mill PPT 11AM 12PM Online Confirmed All Mtech 7 Vedanta Group Interview 3PM Onwards Online Confirmed ICE 12 |
+| 4 March 2026 | Vedanta Group Interview 9AM 6PM Online CHE, ME and ICE 9 Vardhman Interview 9AM 6PM Online Confirmed MBA 5.5 NPCI Online Test 11AM 3PM Online Confirmed B.Tech all Circuital 35K |
+| 5 March 2026 | Shriram Finace Interview 10Am 4PM Online All B.Tech and MBA 6 Travclan Online Test 10AM 2PM Online CSE, IT, ECE, EE, ICE 6-9 LPA DCM Shri Ram Sugar Mill Online Test 10AM 1PM Online Confirmed M.Tech All 8 |
+| 6 March 2026 | Aditya Fashion Interview 3PM 6Pm Visit Confirmed TT 30K Shriram Finance Interview 10AM 6PM Online Confirmed All B.Tech and MBA 6 LPA |
+| 7 March 2026 | Morephan Labotories Full Process 9AM 9PM Visit Confirmed BT, ME and CHE 24K Per month |
+| 17 March 2026 | ColorJet India Limited Interview 10AM 1PM Online Confirmed TT 5 |
+| 19 March 2026 | Kaizen GD 9AM 9PM Online Confirmed IPE 5.75 |
+| 20 March 2026 | Jindal Steel Full Process 9AM 9PM Visit CHE,ME, Civil, EE, ECE, ICE and IPE 10 LPA Vedanta Group Interview 9AM 9PM Online Confirmed ME, CHE & ICE 8 |
+| 21 March 2026 | Morephan Labotories Full Process 9AM Visit Date not confirmed BT, ME and CHE 24K Per Month |
+| 23 March 2026 | IBM Group Interview 9AM 9PM Visit not confirmed yet CSE,IT 8.25 LPA UST AI & Technology Not Confirmed Yet CSE, ECE, IT (B.Tech & M.Tech) 12 |
+| 24 March 2026 | WebTech Interviews 9AM 9PM Online CSE,ICE,ECE,IT, DS, AI, etc. 35K Per Month |
+| 25 March 2026 | Tata Power Interview 9AM 9PM Visit Not Confirmed Yet CSE/IT 9 |
+| 26 March 2026 | Blacklead Infratech Private Limited Not Confirmed Yet Civil 30K Per Month fixed |
+| 27 March 2026 | Delhivery Interviews Online Not Confirmed Yet MBA 6 |

--- a/assets/redditPosts/company_visits_november_2025.md
+++ b/assets/redditPosts/company_visits_november_2025.md
@@ -1,0 +1,23 @@
+# NITJ Company Recruitment Visits & Schedules - November 2025
+
+Below is the list of companies visiting, online tests, interviews, and packages for **November 2025**:
+
+| Date | Event Details / Company / CTC / Eligible Branches |
+| :--- | :--- |
+| 11 November 2025 | IBM Interview 9 AM 9 PM Online Confirmed CSE,ECE,IT,EE,ICE 11 |
+| 12 November 2025 | Maruti Suzuki Online Test 1 PM 11 PM Online Confirmed ME,EE,IT,CSE 9.56 Honda Cars Interview 9 AM 7 PM Visit Confirmed EE,ME,IPE 6 Accenture Interview 9 AM 9 PM Online Confirmed All Branches 11.89 (10.89+1) |
+| 13 November 2025 | Bharti Airtel Online Test 10 AM 12:30 PM Online Confirmed CSE,ECE,IT,EE,ICE 14.75 Yamaha PPT & Online Test 9 AM 4 PM Visit Confirmed IPE 7.50 Hevells Online Test 5 PM 7 PM Online Confirmed CSE,IT,ECE,ICE,EE 10 Incubyte PPT 6 PM 7 PM Online Confirmed CSE,ECE,IT,EE,ICE 6-8 |
+| 14 November 2025 | Yamaha Interview 9 AM 6 PM Visit Confirmed IPE 7.50 Sunpharma Online Test 9 AM 6 PM Online Confirmed CHE,ME,ICE 8 |
+| 15 November 2025 | Sunpharma Interview 9 AM 6 PM Online Confirmed CHE,ME,ICE 8 ITC Limited (Intern 2m) Online Test 9 AM 6 PM Online Confirmed ME 50K |
+| 17 November 2025 | Sunpharma Online Test 9AM 9PM Online Confirmed ICE 8 |
+| 18 November 2025 | Sunpharma Interview 9AM 9PM Online Confirmed ICE 8 |
+| 19 November 2025 | HMEL GD & Interview 9 AM 9 PM Visit Confirmed CHE,ME,ICE,EE 9.20 Havells Interview 9AM 9PM Online Confirmed CSE,ECE,IT,EE,ICE 10 Globallogic Full Process 9AM 3PM Online Confirmed ICE & EE 8 |
+| 20 November 2025 | HMEL Interview 9 AM 9 PM Visit Confirmed CHE,ME,ICE,EE 9.20 Mondelez Full Process 9 AM 9 PM Visit Confirmed ME,IPE,CHE,ECE,ICE,EE 13.81 Havells Interview 10AM 5PM Online Confirmed CSE,ECE,IT,EE,ICE 10 Innovaccer online Test 10AM 1PM Online Not Confirmed All Branches 14 |
+| 21 November 2025 | Inox India Full Process 9 AM 9 PM Visit Confirmed CHE,ICE,EE,ME 4.25 Samsung SRI Full Process 9 AM 9 PM Visit Confirmed CSE,ECE,IT,EE 15.50 Aakash Institute Online test 12pm Onwards Online Confirmed All Btech mtech msc 7.25 |
+| 22 November 2025 | Innovaccer Interview 9 AM 9 PM Visit Confirmed All Branches 12 and 14 |
+| 24 November 2025 | Airtel Interview 9AM 9 PM Online Confirmed CSE,ECE,IT,EE,ICE 14.75 JSL Interview 9AM 9PM Visit TBA Suzuki motors PPT 2PM Onwards Online Confirmed Civil, ME, EE & IPE 7.70 |
+| 25 November 2025 | Amantya Technology Full Process 9 AM 9 PM Visit Confirmed CSE,IT or ECE 6 |
+| 26 November 2025 | Punjab Chemical & Corp Full Process 9 AM 9 PM Visit Confirmed CHE 5.50 Mphasis PPT 10AM 12PM Online Confirmed CSE,ECE,IT,EE,ICE 6 |
+| 27 November 2025 | V A Tech Wabag Full Process 9AM 9PM Visit Confirmed CHE, EE,ME, IPE,Civil,Stru,ICE 5 Mphasis Online Test 9AM 9PM Online Not Confirmed CSE,ECE,IT,EE,ICE 6 Amantya Technology Full Process 9 AM 9 PM Visit Confirmed CSE,ECE,IT 6 |
+| 28 November 2025 | Design2Occupancy Services LLP Full Process 9AM 9PM Visit Confirmed Civil, ME and EE 5 Square Corporation Full Process 9AM 9PM Visit Confirmed TT & IPE 4.20 Reliance Consumer Products Limited Full Process 9AM 9PM Visit Confirmed EE, ME & ICE 8 Siriusai Online Test 3PM Onwards Online Confirmed CSE,ECE,IT,EE,ICE 11.80 |
+| 29 November 2025 | Mphasis Interview 9AM 9PM Online Wabag CSE,ECE,IT,EE,ICE 6 |

--- a/assets/redditPosts/placements_2026_bio_technology.md
+++ b/assets/redditPosts/placements_2026_bio_technology.md
@@ -1,0 +1,49 @@
+# NITJ 2026 Placement Stats - BIO TECHNOLOGY
+
+## Key Statistics
+- **Total Offers**: 20
+- **Eligible Students**: 31
+- **Unique Students Placed**: 18
+- **Placement Percentage**: 58.06%
+- **Multiple Offers**: 2
+- **Average CTC**: 7.46 LPA
+- **Highest CTC**: 14 LPA
+- **Lowest CTC**: 4 LPA
+
+## Gender Distribution
+- **Offers**: Male (10), Female (10)
+- **Unique**: Male (10), Female (8)
+
+## CTC Buckets
+- **<5 LPA**: 9
+- **5-12 LPA**: 9
+- **12-20 LPA**: 2
+- **20-30 LPA**: 0
+- **30-40 LPA**: 0
+- **40+ LPA**: 0
+
+## Job Type Distribution
+- **Intern+FTE**: 5
+- **Intern+PPO**: 6
+- **FTE**: 3
+- **Intern**: 6
+
+## Category Distribution
+- **General**: 7
+- **OBC-NCL**: 8
+- **GEN-EWS**: 3
+- **SC**: 2
+
+## Top Companies by Offers
+- **Addictive Learning Technologies LTD**: 4 offers
+- **Guangdong Academy of Agricultural Sciences**: 1 offers
+- **Sunpharma**: 1 offers
+- **EXL**: 1 offers
+- **Innovaccer**: 1 offers
+
+## Top Companies by Avg CTC
+- **Innovaccer**: 14 LPA
+- **Guangdong Academy of Agricultural Sciences**: 12 LPA
+- **Sunpharma**: 8 LPA
+- **Mindseekers Technologies Pvt. Ltd.!**: 8 LPA
+- **EXL**: 7.5 LPA

--- a/assets/redditPosts/placements_2026_chemical_engineering.md
+++ b/assets/redditPosts/placements_2026_chemical_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - CHEMICAL ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 75
+- **Eligible Students**: 74
+- **Unique Students Placed**: 63
+- **Placement Percentage**: 85.14%
+- **Multiple Offers**: 11
+- **Average CTC**: 10.16 LPA
+- **Highest CTC**: 116 LPA
+- **Lowest CTC**: 4.25 LPA
+
+## Gender Distribution
+- **Offers**: Male (56), Female (19)
+- **Unique**: Male (45), Female (18)
+
+## CTC Buckets
+- **<5 LPA**: 7
+- **5-12 LPA**: 58
+- **12-20 LPA**: 9
+- **20-30 LPA**: 0
+- **30-40 LPA**: 0
+- **40+ LPA**: 1
+
+## Job Type Distribution
+- **FTE**: 56
+- **Intern+FTE**: 7
+- **Intern+PPO**: 6
+- **Intern**: 6
+
+## Category Distribution
+- **OBC-NCL**: 29
+- **SC**: 8
+- **GEN-EWS**: 21
+- **General**: 15
+- **ST**: 2
+
+## Top Companies by Offers
+- **HPCL-Mittal Energy Limited**: 9 offers
+- **Honeywell**: 8 offers
+- **Reliance Industries Ltd**: 6 offers
+- **IOL Chemicals and Pharmaceuticals Limited, Barnala, Punjab.**: 4 offers
+- **Nayara Energy Limited**: 4 offers
+
+## Top Companies by Avg CTC
+- **Flow Trades Hong Kong Services Ltd.**: 116 LPA
+- **Meesho**: 17.5 LPA
+- **Amazon**: 15.5 LPA
+- **Flipkart**: 14.5 LPA
+- **Mondelez International (FTE)**: 13.81 LPA

--- a/assets/redditPosts/placements_2026_civil_engineering.md
+++ b/assets/redditPosts/placements_2026_civil_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - CIVIL ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 57
+- **Eligible Students**: 72
+- **Unique Students Placed**: 48
+- **Placement Percentage**: 66.67%
+- **Multiple Offers**: 6
+- **Average CTC**: 7.4 LPA
+- **Highest CTC**: 15.5 LPA
+- **Lowest CTC**: 3.6 LPA
+
+## Gender Distribution
+- **Offers**: Male (43), Female (14)
+- **Unique**: Male (34), Female (14)
+
+## CTC Buckets
+- **<5 LPA**: 8
+- **5-12 LPA**: 43
+- **12-20 LPA**: 6
+- **20-30 LPA**: 0
+- **30-40 LPA**: 0
+- **40+ LPA**: 0
+
+## Job Type Distribution
+- **FTE**: 34
+- **Intern+PPO**: 14
+- **Intern+FTE**: 5
+- **Intern**: 4
+
+## Category Distribution
+- **General**: 22
+- **GEN-EWS**: 12
+- **OBC-NCL**: 19
+- **ST**: 1
+- **SC**: 3
+
+## Top Companies by Offers
+- **Larsen & Toubro Ltd.**: 8 offers
+- **Juniper Green Energy**: 3 offers
+- **Design2Occupancy Services LLP**: 3 offers
+- **KEC International**: 3 offers
+- **Reliance Industries Ltd**: 2 offers
+
+## Top Companies by Avg CTC
+- **Amazon**: 15.5 LPA
+- **Future First**: 14 LPA
+- **Dyyota Tech Pvt. Ltd.,**: 14 LPA
+- **OPTUM**: 13.84 LPA
+- **Optum Computational Engineering**: 13.24 LPA

--- a/assets/redditPosts/placements_2026_computer_science_and_engineering.md
+++ b/assets/redditPosts/placements_2026_computer_science_and_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - COMPUTER SCIENCE AND ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 166
+- **Eligible Students**: 132
+- **Unique Students Placed**: 130
+- **Placement Percentage**: 98.48%
+- **Multiple Offers**: 32
+- **Average CTC**: 17.24 LPA
+- **Highest CTC**: 52 LPA
+- **Lowest CTC**: 3.6 LPA
+
+## Gender Distribution
+- **Offers**: Male (130), Female (36)
+- **Unique**: Male (101), Female (29)
+
+## CTC Buckets
+- **<5 LPA**: 8
+- **5-12 LPA**: 65
+- **12-20 LPA**: 50
+- **20-30 LPA**: 26
+- **30-40 LPA**: 4
+- **40+ LPA**: 13
+
+## Job Type Distribution
+- **FTE**: 75
+- **Intern+FTE**: 52
+- **Intern+PPO**: 31
+- **Intern**: 8
+
+## Category Distribution
+- **GEN-EWS**: 29
+- **General**: 71
+- **OBC-NCL**: 44
+- **SC**: 19
+- **ST**: 3
+
+## Top Companies by Offers
+- **Oracle**: 9 offers
+- **Accenture**: 8 offers
+- **MAQ Software**: 8 offers
+- **Microsoft**: 6 offers
+- **OPTUM**: 6 offers
+
+## Top Companies by Avg CTC
+- **Microsoft**: 52 LPA
+- **Google**: 52 LPA
+- **Amazon**: 50.2 LPA
+- **Matiks Mental Arithmetic Private Ltd**: 32 LPA
+- **Expedia Group**: 31 LPA

--- a/assets/redditPosts/placements_2026_electrical_engineering.md
+++ b/assets/redditPosts/placements_2026_electrical_engineering.md
@@ -1,0 +1,49 @@
+# NITJ 2026 Placement Stats - ELECTRICAL ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 52
+- **Eligible Students**: 53
+- **Unique Students Placed**: 43
+- **Placement Percentage**: 81.13%
+- **Multiple Offers**: 9
+- **Average CTC**: 11.94 LPA
+- **Highest CTC**: 52 LPA
+- **Lowest CTC**: 4.25 LPA
+
+## Gender Distribution
+- **Offers**: Male (41), Female (11)
+- **Unique**: Male (34), Female (9)
+
+## CTC Buckets
+- **<5 LPA**: 1
+- **5-12 LPA**: 33
+- **12-20 LPA**: 13
+- **20-30 LPA**: 3
+- **30-40 LPA**: 0
+- **40+ LPA**: 2
+
+## Job Type Distribution
+- **Intern+PPO**: 8
+- **Intern+FTE**: 7
+- **FTE**: 37
+
+## Category Distribution
+- **General**: 18
+- **GEN-EWS**: 10
+- **OBC-NCL**: 15
+- **ST**: 3
+- **SC**: 6
+
+## Top Companies by Offers
+- **Reliance Industries Ltd**: 4 offers
+- **Tredence**: 3 offers
+- **OPTUM**: 3 offers
+- **Aditya Birla Management Corporation. Pvt Ltd.**: 3 offers
+- **ICICI Bank**: 2 offers
+
+## Top Companies by Avg CTC
+- **Microsoft**: 52 LPA
+- **Amazon**: 52 LPA
+- **Oracle**: 21.89 LPA
+- **UKG (Ultimate Kronos Group)**: 21.62 LPA
+- **OPTUM**: 19.21 LPA

--- a/assets/redditPosts/placements_2026_electronics_and_communication_engineering.md
+++ b/assets/redditPosts/placements_2026_electronics_and_communication_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - ELECTRONICS AND COMMUNICATION ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 92
+- **Eligible Students**: 102
+- **Unique Students Placed**: 75
+- **Placement Percentage**: 73.53%
+- **Multiple Offers**: 15
+- **Average CTC**: 14.2 LPA
+- **Highest CTC**: 52 LPA
+- **Lowest CTC**: 4 LPA
+
+## Gender Distribution
+- **Offers**: Male (69), Female (23)
+- **Unique**: Male (56), Female (19)
+
+## CTC Buckets
+- **<5 LPA**: 8
+- **5-12 LPA**: 41
+- **12-20 LPA**: 28
+- **20-30 LPA**: 10
+- **30-40 LPA**: 2
+- **40+ LPA**: 3
+
+## Job Type Distribution
+- **FTE**: 54
+- **Intern+FTE**: 13
+- **Intern+PPO**: 21
+- **Intern**: 4
+
+## Category Distribution
+- **GEN-EWS**: 12
+- **OBC-NCL**: 28
+- **General**: 38
+- **SC**: 9
+- **ST**: 5
+
+## Top Companies by Offers
+- **Bharat Electronics Limited (BEL)**: 8 offers
+- **Accenture**: 6 offers
+- **Elevate Standard**: 5 offers
+- **HSBC Technology**: 4 offers
+- **Silicon Labs**: 4 offers
+
+## Top Companies by Avg CTC
+- **Microsoft**: 52 LPA
+- **Amazon**: 52 LPA
+- **Silicon Labs**: 30 LPA
+- **NXP Semiconductors (B.Tech)**: 26 LPA
+- **CISCO**: 24.73 LPA

--- a/assets/redditPosts/placements_2026_industrial_and_production_engineering.md
+++ b/assets/redditPosts/placements_2026_industrial_and_production_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - INDUSTRIAL AND PRODUCTION ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 71
+- **Eligible Students**: 71
+- **Unique Students Placed**: 60
+- **Placement Percentage**: 84.51%
+- **Multiple Offers**: 11
+- **Average CTC**: 9.07 LPA
+- **Highest CTC**: 21 LPA
+- **Lowest CTC**: 3.78 LPA
+
+## Gender Distribution
+- **Offers**: Male (59), Female (12)
+- **Unique**: Male (50), Female (10)
+
+## CTC Buckets
+- **<5 LPA**: 9
+- **5-12 LPA**: 46
+- **12-20 LPA**: 14
+- **20-30 LPA**: 2
+- **30-40 LPA**: 0
+- **40+ LPA**: 0
+
+## Job Type Distribution
+- **FTE**: 47
+- **Intern+FTE**: 9
+- **Intern+PPO**: 12
+- **Intern**: 3
+
+## Category Distribution
+- **General**: 19
+- **GEN-EWS**: 14
+- **OBC-NCL**: 21
+- **SC**: 12
+- **ST**: 5
+
+## Top Companies by Offers
+- **Maxop**: 6 offers
+- **Sunpharma**: 5 offers
+- **Urban Company**: 5 offers
+- **JSW**: 5 offers
+- **Amazon**: 4 offers
+
+## Top Companies by Avg CTC
+- **Engineer India Limited**: 21 LPA
+- **Meesho**: 17.5 LPA
+- **FNZ Technology (India) Private Limited**: 17 LPA
+- **Amazon**: 15.5 LPA
+- **Flipkart**: 14.5 LPA

--- a/assets/redditPosts/placements_2026_information_technology.md
+++ b/assets/redditPosts/placements_2026_information_technology.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - INFORMATION TECHNOLOGY
+
+## Key Statistics
+- **Total Offers**: 104
+- **Eligible Students**: 103
+- **Unique Students Placed**: 85
+- **Placement Percentage**: 82.52%
+- **Multiple Offers**: 17
+- **Average CTC**: 14.33 LPA
+- **Highest CTC**: 52 LPA
+- **Lowest CTC**: 6 LPA
+
+## Gender Distribution
+- **Offers**: Male (81), Female (23)
+- **Unique**: Male (65), Female (20)
+
+## CTC Buckets
+- **<5 LPA**: 8
+- **5-12 LPA**: 47
+- **12-20 LPA**: 34
+- **20-30 LPA**: 10
+- **30-40 LPA**: 0
+- **40+ LPA**: 5
+
+## Job Type Distribution
+- **FTE**: 38
+- **Intern+FTE**: 29
+- **Intern+PPO**: 28
+- **Intern**: 9
+
+## Category Distribution
+- **OBC-NCL**: 26
+- **GEN-EWS**: 15
+- **General**: 52
+- **ST**: 2
+- **SC**: 9
+
+## Top Companies by Offers
+- **Samsung SRI-Delhi**: 7 offers
+- **GlobalLogic**: 6 offers
+- **HSBC Technology**: 4 offers
+- **Amazon**: 4 offers
+- **Accenture**: 3 offers
+
+## Top Companies by Avg CTC
+- **Microsoft**: 52 LPA
+- **Amazon**: 52 LPA
+- **Amazon**: 41.2 LPA
+- **CISCO**: 24.73 LPA
+- **Urban Company**: 24 LPA

--- a/assets/redditPosts/placements_2026_instrumentation_and_control_engineering.md
+++ b/assets/redditPosts/placements_2026_instrumentation_and_control_engineering.md
@@ -1,0 +1,49 @@
+# NITJ 2026 Placement Stats - INSTRUMENTATION AND CONTROL ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 108
+- **Eligible Students**: 96
+- **Unique Students Placed**: 91
+- **Placement Percentage**: 94.79%
+- **Multiple Offers**: 16
+- **Average CTC**: 10.99 LPA
+- **Highest CTC**: 52 LPA
+- **Lowest CTC**: 4 LPA
+
+## Gender Distribution
+- **Offers**: Male (77), Female (31)
+- **Unique**: Male (67), Female (24)
+
+## CTC Buckets
+- **<5 LPA**: 10
+- **5-12 LPA**: 72
+- **12-20 LPA**: 18
+- **20-30 LPA**: 7
+- **30-40 LPA**: 0
+- **40+ LPA**: 1
+
+## Job Type Distribution
+- **FTE**: 72
+- **Intern+PPO**: 14
+- **Intern+FTE**: 16
+- **Intern**: 6
+
+## Category Distribution
+- **SC**: 13
+- **General**: 30
+- **GEN-EWS**: 34
+- **OBC-NCL**: 31
+
+## Top Companies by Offers
+- **Reliance Industries Ltd**: 8 offers
+- **Hindustan Petroleum Corporation Ltd**: 6 offers
+- **Sunpharma**: 6 offers
+- **Global logic ( ELECTRICAL)**: 5 offers
+- **Sigmoid**: 4 offers
+
+## Top Companies by Avg CTC
+- **Amazon**: 52 LPA
+- **ZScaler**: 29.5 LPA
+- **CISCO**: 24.73 LPA
+- **Oracle**: 21.89 LPA
+- **Engineer India Limited**: 21 LPA

--- a/assets/redditPosts/placements_2026_mechanical_engineering.md
+++ b/assets/redditPosts/placements_2026_mechanical_engineering.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - MECHANICAL ENGINEERING
+
+## Key Statistics
+- **Total Offers**: 114
+- **Eligible Students**: 100
+- **Unique Students Placed**: 95
+- **Placement Percentage**: 95%
+- **Multiple Offers**: 19
+- **Average CTC**: 8.31 LPA
+- **Highest CTC**: 20.45 LPA
+- **Lowest CTC**: 3.78 LPA
+
+## Gender Distribution
+- **Offers**: Male (92), Female (22)
+- **Unique**: Male (75), Female (20)
+
+## CTC Buckets
+- **<5 LPA**: 6
+- **5-12 LPA**: 93
+- **12-20 LPA**: 14
+- **20-30 LPA**: 1
+- **30-40 LPA**: 0
+- **40+ LPA**: 0
+
+## Job Type Distribution
+- **Intern+PPO**: 18
+- **FTE**: 85
+- **Intern+FTE**: 9
+- **Intern**: 2
+
+## Category Distribution
+- **GEN-EWS**: 26
+- **General**: 34
+- **SC**: 16
+- **OBC-NCL**: 35
+- **ST**: 3
+
+## Top Companies by Offers
+- **Maruti Suzuki India**: 6 offers
+- **Jindal Steel Ltd.**: 6 offers
+- **HPCL-Mittal Energy Limited**: 5 offers
+- **Honda Cars India Ltd.**: 4 offers
+- **Design2Occupancy Services LLP**: 4 offers
+
+## Top Companies by Avg CTC
+- **Bharat Petroleum Corporation Limited**: 20.45 LPA
+- **Amazon**: 15.5 LPA
+- **Flipkart**: 14.5 LPA
+- **Future First**: 14 LPA
+- **Tata Steel**: 13.7 LPA

--- a/assets/redditPosts/placements_2026_textile_technology.md
+++ b/assets/redditPosts/placements_2026_textile_technology.md
@@ -1,0 +1,50 @@
+# NITJ 2026 Placement Stats - TEXTILE TECHNOLOGY
+
+## Key Statistics
+- **Total Offers**: 64
+- **Eligible Students**: 57
+- **Unique Students Placed**: 54
+- **Placement Percentage**: 94.74%
+- **Multiple Offers**: 9
+- **Average CTC**: 6.34 LPA
+- **Highest CTC**: 17 LPA
+- **Lowest CTC**: 3.6 LPA
+
+## Gender Distribution
+- **Offers**: Male (52), Female (12)
+- **Unique**: Male (43), Female (11)
+
+## CTC Buckets
+- **<5 LPA**: 36
+- **5-12 LPA**: 21
+- **12-20 LPA**: 7
+- **20-30 LPA**: 0
+- **30-40 LPA**: 0
+- **40+ LPA**: 0
+
+## Job Type Distribution
+- **Intern**: 8
+- **FTE**: 45
+- **Intern+PPO**: 10
+- **Intern+FTE**: 1
+
+## Category Distribution
+- **OBC-NCL**: 24
+- **SC**: 10
+- **GEN-EWS**: 14
+- **General**: 14
+- **ST**: 2
+
+## Top Companies by Offers
+- **Sportsking**: 8 offers
+- **Sangam India Limited**: 7 offers
+- **Reliance Industries Ltd**: 6 offers
+- **Vardhman Textile**: 4 offers
+- **Anatech Consulting Services**: 4 offers
+
+## Top Companies by Avg CTC
+- **FNZ Technology (India) Private Limited**: 17 LPA
+- **Amazon**: 15.5 LPA
+- **Jay Jay Mills (Pvt) LTD**: 13.5 LPA
+- **Trident Group**: 12 LPA
+- **Zomato**: 10 LPA

--- a/assets/redditPosts/placements_overview_2026.md
+++ b/assets/redditPosts/placements_overview_2026.md
@@ -1,0 +1,58 @@
+# NITJ Placement Statistics 2026 Overview
+
+## Overall Statistics
+- **Total Offers**: 923
+- **Unique Placements**: 762
+- **Double Placements**: 147
+- **Average CTC**: 11.05 LPA
+- **Highest CTC**: 116 LPA
+- **Lowest CTC**: 3.6 LPA
+- **Median CTC**: 9.31 LPA
+- **Overall Placement Percentage**: 85.52%
+- **Total Eligible Students**: 891
+- **Total Companies Visited**: 349
+- **On-Campus Companies**: 256
+- **Off-Campus Companies**: 61
+- **Summer Internship Companies**: 32
+
+## Placement by Department (Offers)
+- **TEXTILE TECHNOLOGY**: 64 offers
+- **COMPUTER SCIENCE AND ENGINEERING**: 166 offers
+- **ELECTRONICS AND COMMUNICATION ENGINEERING**: 92 offers
+- **INFORMATION TECHNOLOGY**: 104 offers
+- **INSTRUMENTATION AND CONTROL ENGINEERING**: 108 offers
+- **CHEMICAL ENGINEERING**: 75 offers
+- **ELECTRICAL ENGINEERING**: 52 offers
+- **MECHANICAL ENGINEERING**: 114 offers
+- **CIVIL ENGINEERING**: 57 offers
+- **INDUSTRIAL AND PRODUCTION ENGINEERING**: 71 offers
+- **BIO TECHNOLOGY**: 20 offers
+
+## CTC Buckets
+- **<5 LPA**: 110 students
+- **5-12 LPA**: 528 students
+- **12-20 LPA**: 195 students
+- **20-30 LPA**: 59 students
+- **30-40 LPA**: 6 students
+- **40+ LPA**: 25 students
+
+## Gender Distribution
+- **Total Offers**: Male (710), Female (213)
+- **Unique Placements**: Male (580), Female (182)
+
+## Job Type Distribution
+- **Intern**: 56
+- **FTE**: 546
+- **Intern+FTE**: 153
+- **Intern+PPO**: 168
+
+## Sector Distribution
+- **Private Sector**: 900 offers
+- **PSU**: 23 offers
+
+## Top Companies by Count
+- **Reliance Industries Ltd**: 31 offers
+- **Accenture**: 21 offers
+- **Accenture**: 19 offers
+- **HPCL-Mittal Energy Limited**: 18 offers
+- **Oracle**: 17 offers

--- a/handlers/embedding.js
+++ b/handlers/embedding.js
@@ -99,7 +99,7 @@ async function getRelevantContextFromPgvector(item, isDM) {
     const wikiDir = './assets/redditPosts/';
     let wikiContext = '';
     if (fs.existsSync(wikiDir)) {
-      const wikiFiles = fs.readdirSync(wikiDir).filter(file => file.endsWith('.txt'));
+      const wikiFiles = fs.readdirSync(wikiDir).filter(file => file.endsWith('.txt') || file.endsWith('.md'));
       const wikiSimilarities = [];
 
       for (const file of wikiFiles) {


### PR DESCRIPTION
This pull request adds detailed schedules for company recruitment visits, online tests, and interviews for NITJ students covering December 2025 through March 2026. The information is provided both as a comprehensive markdown file and as individual monthly summaries for easy reference.

**Key changes:**

**Addition of comprehensive company visit schedule:**
- Added a new file, `companies2026.md`, listing all company processes, dates, times, eligibility, and compensation details for November 2025 to March 2026, serving as a master schedule.

**Monthly breakdowns for easier access:**
- Added `company_visits_december_2025.md` summarizing all company visits, interviews, and tests for December 2025 in a clear table format.
- Added `company_visits_january_2026.md` summarizing company recruitment events for January 2026.
- Added `company_visits_february_2026.md` summarizing company recruitment events for February 2026.
- Added `company_visits_march_2026.md` summarizing company recruitment events for March 2026.